### PR TITLE
Add test cases for `test_div`

### DIFF
--- a/test/test_bigdecimal.rb
+++ b/test/test_bigdecimal.rb
@@ -728,6 +728,12 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(BigDecimal('1486.868686869'), BigDecimal('1472.0') / BigDecimal('0.99'), '[ruby-core:59365] [#9316]')
 
     assert_equal(4.124045235, BigDecimal('0.9932') / (700 * BigDecimal('0.344045') / BigDecimal('1000.0')), '[#9305]')
+
+    BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)
+    assert_positive_zero(BigDecimal.new("1.0")  / BigDecimal.new("Infinity"))
+    assert_negative_zero(BigDecimal.new("-1.0") / BigDecimal.new("Infinity"))
+    assert_negative_zero(BigDecimal.new("1.0")  / BigDecimal.new("-Infinity"))
+    assert_positive_zero(BigDecimal.new("-1.0") / BigDecimal.new("-Infinity"))
   end
 
   def test_div_with_float


### PR DESCRIPTION
Add test cases to ensure which sign will be returned
when BigDecimal is divided by infinity.