### PR TITLE
Add test cases for `BigDecimal#round`

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -479,7 +479,10 @@ check_rounding_mode_option(VALUE const opts)
         break;
     }
   invalid:
-    rb_raise(rb_eArgError, "invalid rounding mode: %"PRIsVALUE, mode);
+    if (NIL_P(mode))
+	rb_raise(rb_eArgError, "invalid rounding mode: nil");
+    else
+	rb_raise(rb_eArgError, "invalid rounding mode: %"PRIsVALUE, mode);
 
   noopt:
     return VpGetRoundMode();

--- a/test/test_bigdecimal.rb
+++ b/test/test_bigdecimal.rb
@@ -1058,6 +1058,11 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(BigDecimal('-7.1364'), BigDecimal('-7.1364499').round(4, half: :down))
   end
 
+  def test_round_half_invalid_option
+    assert_raise_with_message(ArgumentError, "invalid rounding mode: invalid") { BigDecimal('12.5').round(half: :invalid) }
+    assert_raise_with_message(ArgumentError, "invalid rounding mode: invalid") { BigDecimal('2.15').round(1, half: :invalid) }
+  end
+
   def test_truncate
     assert_equal(3, BigDecimal.new("3.14159").truncate)
     assert_equal(8, BigDecimal.new("8.7").truncate)

--- a/test/test_bigdecimal.rb
+++ b/test/test_bigdecimal.rb
@@ -1061,6 +1061,7 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_round_half_invalid_option
     assert_raise_with_message(ArgumentError, "invalid rounding mode: invalid") { BigDecimal('12.5').round(half: :invalid) }
     assert_raise_with_message(ArgumentError, "invalid rounding mode: invalid") { BigDecimal('2.15').round(1, half: :invalid) }
+    assert_raise_with_message(ArgumentError, "invalid rounding mode: nil") { BigDecimal('12.5').round(half: nil) }
   end
 
   def test_truncate


### PR DESCRIPTION
To ensure `ArgumentError` is raised if an invalid value is
passed to `BigDecimal#round`.