### PR TITLE
Make error messages of `#sqrt` clear

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -5816,13 +5816,13 @@ VpSqrt(Real *y, Real *x)
     /* Negative ? */
     if (x->sign < 0) {
 	VpSetNaN(y);
-	return VpException(VP_EXCEPTION_OP, "(VpSqrt) SQRT(negative value)", 0);
+	return VpException(VP_EXCEPTION_OP, "sqrt of negative value", 0);
     }
 
     /* NaN ? */
     if (VpIsNaN(x)) {
 	VpSetNaN(y);
-	return VpException(VP_EXCEPTION_OP, "(VpSqrt) SQRT(NaN)", 0);
+	return VpException(VP_EXCEPTION_OP, "sqrt of 'NaN'(Not a Number)", 0);
     }
 
     /* One ? */

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -5807,20 +5807,22 @@ VpSqrt(Real *y, Real *x)
     ssize_t nr;
     double val;
 
-    /* Zero, NaN or Infinity ? */
-    if (!VpHasVal(x)) {
-	if (VpIsZero(x) || VpGetSign(x) > 0) {
-	    VpAsgn(y,x,1);
-	    goto Exit;
-	}
-	VpSetNaN(y);
-	return VpException(VP_EXCEPTION_OP, "(VpSqrt) SQRT(NaN or negative value)", 0);
+    /* Zero or +Infinity ? */
+    if (VpIsZero(x) || VpIsPosInf(x)) {
+	VpAsgn(y,x,1);
+	goto Exit;
     }
 
     /* Negative ? */
-    if (VpGetSign(x) < 0) {
+    if (x->sign < 0) {
 	VpSetNaN(y);
 	return VpException(VP_EXCEPTION_OP, "(VpSqrt) SQRT(negative value)", 0);
+    }
+
+    /* NaN ? */
+    if (VpIsNaN(x)) {
+	VpSetNaN(y);
+	return VpException(VP_EXCEPTION_OP, "(VpSqrt) SQRT(NaN)", 0);
     }
 
     /* One ? */

--- a/test/test_bigdecimal.rb
+++ b/test/test_bigdecimal.rb
@@ -910,14 +910,14 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(true, (x.sqrt(200) - y).abs < BigDecimal("1E#{e-200}"))
     assert_equal(true, (x.sqrt(300) - y).abs < BigDecimal("1E#{e-300}"))
     x = BigDecimal.new("-" + (2**100).to_s)
-    assert_raise_with_message(FloatDomainError, "(VpSqrt) SQRT(negative value)") { x.sqrt(1) }
+    assert_raise_with_message(FloatDomainError, "sqrt of negative value") { x.sqrt(1) }
     x = BigDecimal.new((2**200).to_s)
     assert_equal(2**100, x.sqrt(1))
 
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-    assert_raise_with_message(FloatDomainError, "(VpSqrt) SQRT(NaN)") { BigDecimal.new("NaN").sqrt(1) }
-    assert_raise_with_message(FloatDomainError, "(VpSqrt) SQRT(negative value)") { BigDecimal.new("-Infinity").sqrt(1) }
+    assert_raise_with_message(FloatDomainError, "sqrt of 'NaN'(Not a Number)") { BigDecimal.new("NaN").sqrt(1) }
+    assert_raise_with_message(FloatDomainError, "sqrt of negative value") { BigDecimal.new("-Infinity").sqrt(1) }
 
     assert_equal(0, BigDecimal.new("0").sqrt(1))
     assert_equal(0, BigDecimal.new("-0").sqrt(1))

--- a/test/test_bigdecimal.rb
+++ b/test/test_bigdecimal.rb
@@ -917,9 +917,12 @@ class TestBigDecimal < Test::Unit::TestCase
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
     assert_raise(FloatDomainError) { BigDecimal.new("NaN").sqrt(1) }
+    assert_raise(FloatDomainError) { BigDecimal.new("-Infinity").sqrt(1) }
 
     assert_equal(0, BigDecimal.new("0").sqrt(1))
+    assert_equal(0, BigDecimal.new("-0").sqrt(1))
     assert_equal(1, BigDecimal.new("1").sqrt(1))
+    assert_positive_infinite(BigDecimal.new("Infinity").sqrt(1))
   end
 
   def test_sqrt_5266

--- a/test/test_bigdecimal.rb
+++ b/test/test_bigdecimal.rb
@@ -916,8 +916,8 @@ class TestBigDecimal < Test::Unit::TestCase
 
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-    assert_raise_with_message(FloatDomainError, "(VpSqrt) SQRT(NaN or negative value)") { BigDecimal.new("NaN").sqrt(1) }
-    assert_raise_with_message(FloatDomainError, "(VpSqrt) SQRT(NaN or negative value)") { BigDecimal.new("-Infinity").sqrt(1) }
+    assert_raise_with_message(FloatDomainError, "(VpSqrt) SQRT(NaN)") { BigDecimal.new("NaN").sqrt(1) }
+    assert_raise_with_message(FloatDomainError, "(VpSqrt) SQRT(negative value)") { BigDecimal.new("-Infinity").sqrt(1) }
 
     assert_equal(0, BigDecimal.new("0").sqrt(1))
     assert_equal(0, BigDecimal.new("-0").sqrt(1))

--- a/test/test_bigdecimal.rb
+++ b/test/test_bigdecimal.rb
@@ -910,14 +910,14 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(true, (x.sqrt(200) - y).abs < BigDecimal("1E#{e-200}"))
     assert_equal(true, (x.sqrt(300) - y).abs < BigDecimal("1E#{e-300}"))
     x = BigDecimal.new("-" + (2**100).to_s)
-    assert_raise(FloatDomainError) { x.sqrt(1) }
+    assert_raise_with_message(FloatDomainError, "(VpSqrt) SQRT(negative value)") { x.sqrt(1) }
     x = BigDecimal.new((2**200).to_s)
     assert_equal(2**100, x.sqrt(1))
 
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-    assert_raise(FloatDomainError) { BigDecimal.new("NaN").sqrt(1) }
-    assert_raise(FloatDomainError) { BigDecimal.new("-Infinity").sqrt(1) }
+    assert_raise_with_message(FloatDomainError, "(VpSqrt) SQRT(NaN or negative value)") { BigDecimal.new("NaN").sqrt(1) }
+    assert_raise_with_message(FloatDomainError, "(VpSqrt) SQRT(NaN or negative value)") { BigDecimal.new("-Infinity").sqrt(1) }
 
     assert_equal(0, BigDecimal.new("0").sqrt(1))
     assert_equal(0, BigDecimal.new("-0").sqrt(1))


### PR DESCRIPTION
`BigDecimal.new("-Infinity").sqrt` raises an error because this is negative value, not NaN.