### PR TITLE
Change `#round` to accept `{ half: nil }` to follow r57130

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -459,7 +459,7 @@ check_rounding_mode_option(VALUE const opts)
         goto noopt;
 
     mode = rb_hash_lookup2(opts, ID2SYM(id_half), Qundef);
-    if (mode == Qundef)
+    if (mode == Qundef || NIL_P(mode))
         goto noopt;
 
     if (SYMBOL_P(mode))

--- a/test/test_bigdecimal.rb
+++ b/test/test_bigdecimal.rb
@@ -1082,10 +1082,48 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(BigDecimal('-7.1364'), BigDecimal('-7.1364499').round(4, half: :down))
   end
 
+  def test_round_half_nil
+    x = BigDecimal.new("2.5")
+
+    BigDecimal.save_rounding_mode do
+      BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_UP)
+      assert_equal(3, x.round(0, half: nil))
+    end
+
+    BigDecimal.save_rounding_mode do
+      BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_DOWN)
+      assert_equal(2, x.round(0, half: nil))
+    end
+
+    BigDecimal.save_rounding_mode do
+      BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_HALF_UP)
+      assert_equal(3, x.round(0, half: nil))
+    end
+
+    BigDecimal.save_rounding_mode do
+      BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_HALF_DOWN)
+      assert_equal(2, x.round(0, half: nil))
+    end
+
+    BigDecimal.save_rounding_mode do
+      BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_HALF_EVEN)
+      assert_equal(2, x.round(0, half: nil))
+    end
+
+    BigDecimal.save_rounding_mode do
+      BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_CEILING)
+      assert_equal(3, x.round(0, half: nil))
+    end
+
+    BigDecimal.save_rounding_mode do
+      BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_FLOOR)
+      assert_equal(2, x.round(0, half: nil))
+    end
+  end
+
   def test_round_half_invalid_option
     assert_raise_with_message(ArgumentError, "invalid rounding mode: invalid") { BigDecimal('12.5').round(half: :invalid) }
     assert_raise_with_message(ArgumentError, "invalid rounding mode: invalid") { BigDecimal('2.15').round(1, half: :invalid) }
-    assert_raise_with_message(ArgumentError, "invalid rounding mode: nil") { BigDecimal('12.5').round(half: nil) }
   end
 
   def test_truncate


### PR DESCRIPTION
By r57130 `Float#round` is changed to accept `{ half: nil }`.
This commit follows the change.
`{ half: nil }` means the default behavior, and the default behavior
of `BigDecimal#round` is to use `BigDecimal::ROUND_MODE`.