### PR TITLE
Remove not used `#have_macro`

### DIFF
--- a/ext/bigdecimal/extconf.rb
+++ b/ext/bigdecimal/extconf.rb
@@ -14,10 +14,6 @@ have_func("rb_rational_den", "ruby.h")
 have_func("rb_array_const_ptr", "ruby.h")
 have_func("rb_sym2str", "ruby.h")
 
-have_macro("FIX_CONST_VALUE_PTR", "ruby.h")
-have_macro("RARRAY_CONST_PTR", "ruby.h")
-have_macro("RARRAY_AREF", "ruby.h")
-
 create_makefile('bigdecimal')
 
 # Add additional dependencies


### PR DESCRIPTION
After 53ca1882782bc05a5352020cf06e96ee19b5816a,
`have_macro` have been not used (`Kernel#have_macro` only checks
macro is defined or not).