### PR TITLE
Drop ruby 1_9_3 from CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ rvm:
 - 2.2.6
 - 2.1.10
 - 2.0.0
-- 1.9.3
 matrix:
-  allow_failures:
-  - rvm: 1.9.3
 before_install:
 - gem install bundler -v 1.13.7
 script:


### PR DESCRIPTION
Tests for Ruby 1.9.3 have been failed.
There are some reasons why tests on 1.9.3 do not work.

* Invalid syntaxes about keyword args (e.g. `**opt` or `method(a: :b)`)
* A missed macoro (`NUM2USHORT `)

Changing codes to run tests on 1.9.3 is too complex.
So drop 1.9.3 from CI.

close https://github.com/ruby/bigdecimal/issues/52