### PR TITLE
fixes issue: #13062 - String#to_d is not raising error

### DIFF
--- a/lib/bigdecimal/util.rb
+++ b/lib/bigdecimal/util.rb
@@ -58,7 +58,11 @@ class String
   #     # => 0.5e0
   #
   def to_d
-    BigDecimal(self)
+    begin
+      BigDecimal(self)
+    rescue ArgumentError
+      BigDecimal(0)
+    end
   end
 end
 

--- a/test/test_bigdecimal_util.rb
+++ b/test/test_bigdecimal_util.rb
@@ -48,4 +48,13 @@ class TestBigDecimalUtil < Test::Unit::TestCase
   def test_Rational_to_d_with_negative_precision
     assert_raise(ArgumentError) { 355.quo(113).to_d(-42) }
   end
+
+  def test_String_to_d
+    assert_equal("2.5".to_d, BigDecimal.new('2.5'))
+  end
+
+  def test_invalid_String_to_d
+    assert_equal("invalid".to_d, BigDecimal.new('0.0'))
+  end
+
 end


### PR DESCRIPTION
This commit fixes issue with String#to_d method which was inconsistent
with other to_d methods (String one returned error, while other simply
    returns 0).

Also, there tests added for this case.

Associated GH issue: https://github.com/ruby/bigdecimal/issues/51