### PR TITLE
Document bigdecimal/util in the rdoc for BigDecimal

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -3193,6 +3193,19 @@ get_vp_value:
  * Note also that in mathematics, there is no particular concept of negative
  * or positive zero; true mathematical zero has no sign.
  *
+ * == bigdecimal/util
+ *
+ * When you require +bigdecimal/util+, the #to_d method will be
+ * available on BigDecimal and the native Integer, Float, Rational,
+ * and String classes:
+ *
+ *	require 'bigdecimal/util'
+ *
+ *      42.to_d         # => 0.42e2
+ *      0.5.to_d        # => 0.5e0
+ *      (2/3r).to_d(3)  # => 0.667e0
+ *      "0.5".to_d      # => 0.5e0
+ *
  * == License
  *
  * Copyright (C) 2002 by Shigeo Kobayashi <shigeo@tinyforest.gr.jp>.

--- a/lib/bigdecimal/util.rb
+++ b/lib/bigdecimal/util.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: false
 #
+#--
 # bigdecimal/util extends various native classes to provide the #to_d method,
 # and provides BigDecimal#to_d and BigDecimal#to_digits.
+#++
 
 
-# bigdecimal/util extends the native Integer class to provide the #to_d method.
-#
-# When you require 'bigdecimal/util' in your application, this method will
-# be available on Integer objects.
 class Integer < Numeric
   # call-seq:
   #     int.to_d  -> bigdecimal
@@ -25,10 +23,7 @@ class Integer < Numeric
   end
 end
 
-# bigdecimal/util extends the native Float class to provide the #to_d method.
-#
-# When you require 'bigdecimal/util' in your application, this method will be
-# available on Float objects.
+
 class Float < Numeric
   # call-seq:
   #     flt.to_d  -> bigdecimal
@@ -46,10 +41,7 @@ class Float < Numeric
   end
 end
 
-# bigdecimal/util extends the native String class to provide the #to_d method.
-#
-# When you require 'bigdecimal/util' in your application, this method will be
-# available on String objects.
+
 class String
   # call-seq:
   #     string.to_d  -> bigdecimal
@@ -71,11 +63,7 @@ class String
   end
 end
 
-# bigdecimal/util extends the BigDecimal class to provide the #to_digits and
-# #to_d methods.
-#
-# When you require 'bigdecimal/util' in your application, these methods will be
-# available on BigDecimal objects.
+
 class BigDecimal < Numeric
   # call-seq:
   #     a.to_digits -> string
@@ -108,10 +96,7 @@ class BigDecimal < Numeric
   end
 end
 
-# bigdecimal/util extends the native Rational class to provide the #to_d method.
-#
-# When you require 'bigdecimal/util' in your application, this method will be
-# available on Rational objects.
+
 class Rational < Numeric
   # call-seq:
   #   r.to_d(precision)   -> bigdecimal


### PR DESCRIPTION
bigdecimal/util "leaks" some documentation into the class documentation for the extended core classes, e.g.:

```
$ ri Integer
Integer < Numeric

(from ruby site)
------------------------------------------------------------------------------
BigDecimal extends the native Integer class to provide the #to_d method.

When you require the BigDecimal library [...]

[...other stuff that doesn't belong here...]

Holds Integer values.  You cannot add a singleton method to an Integer. Any
attempt to add a singleton method to an Integer object will raise a TypeError.
```

See also https://docs.ruby-lang.org/en/2.4.0/Integer.html, and the rdoc/ri for String, Float, Rational, BigDecimal (section "License").

This PR removes those comments from the extended core classes and instead adds a new section on "bigdecimal/util" to the class documentation for BigDecimal.