### PR TITLE
Correct and extend docs for BigDecimal#div

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -1319,8 +1319,8 @@ BigDecimal_divide(Real **c, Real **res, Real **div, VALUE self, VALUE r)
 }
 
 /* call-seq:
- * a / b
- * quo(value)
+ *   a / b       -> bigdecimal
+ *   quo(value)  -> bigdecimal
  *
  * Divide by the specified value.
  *
@@ -1591,23 +1591,36 @@ BigDecimal_div2(VALUE self, VALUE b, VALUE n)
     }
 }
 
- /* call-seq:
-  * div(value, digits)
+ /*
+  * Document-method: BigDecimal#div
+  *
+  * call-seq:
+  *   div(value, digits)  -> bigdecimal or integer
   *
   * Divide by the specified value.
-  *
-  * e.g.
-  *   c = a.div(b,n)
   *
   * digits:: If specified and less than the number of significant digits of the
   *          result, the result is rounded to that number of digits, according
   *          to BigDecimal.mode.
   *
-  * If digits is 0, the result is the same as the / operator. If not, the
-  * result is an integer BigDecimal, by analogy with Float#div.
+  *          If digits is 0, the result is the same as for the / operator
+  *          or #quo.
   *
-  * The alias quo is provided since <code>div(value, 0)</code> is the same as
-  * computing the quotient; see BigDecimal#divmod.
+  *          If digits is not specified, the result is an integer,
+  *          by analogy with Float#div; see also BigDecimal#divmod.
+  *
+  * Examples:
+  *
+  *   a = BigDecimal("4")
+  *   b = BigDecimal("3")
+  *
+  *   a.div(b, 3)  # => 0.133e1
+  *
+  *   a.div(b, 0)  # => 0.1333333333333333333e1
+  *   a / b        # => 0.1333333333333333333e1
+  *   a.quo(b)     # => 0.1333333333333333333e1
+  *
+  *   a.div(b)     # => 1
   */
 static VALUE
 BigDecimal_div3(int argc, VALUE *argv, VALUE self)

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -1318,25 +1318,14 @@ BigDecimal_divide(Real **c, Real **res, Real **div, VALUE self, VALUE r)
     return Qnil;
 }
 
- /* call-seq:
-  * div(value, digits)
-  * quo(value)
-  *
-  * Divide by the specified value.
-  *
-  * e.g.
-  *   c = a.div(b,n)
-  *
-  * digits:: If specified and less than the number of significant digits of the
-  *          result, the result is rounded to that number of digits, according
-  *          to BigDecimal.mode.
-  *
-  * If digits is 0, the result is the same as the / operator. If not, the
-  * result is an integer BigDecimal, by analogy with Float#div.
-  *
-  * The alias quo is provided since <code>div(value, 0)</code> is the same as
-  * computing the quotient; see BigDecimal#divmod.
-  */
+/* call-seq:
+ * a / b
+ * quo(value)
+ *
+ * Divide by the specified value.
+ *
+ * See BigDecimal#div.
+ */
 static VALUE
 BigDecimal_div(VALUE self, VALUE r)
 /* For c = self/r: with round operation */
@@ -1602,6 +1591,24 @@ BigDecimal_div2(VALUE self, VALUE b, VALUE n)
     }
 }
 
+ /* call-seq:
+  * div(value, digits)
+  *
+  * Divide by the specified value.
+  *
+  * e.g.
+  *   c = a.div(b,n)
+  *
+  * digits:: If specified and less than the number of significant digits of the
+  *          result, the result is rounded to that number of digits, according
+  *          to BigDecimal.mode.
+  *
+  * If digits is 0, the result is the same as the / operator. If not, the
+  * result is an integer BigDecimal, by analogy with Float#div.
+  *
+  * The alias quo is provided since <code>div(value, 0)</code> is the same as
+  * computing the quotient; see BigDecimal#divmod.
+  */
 static VALUE
 BigDecimal_div3(int argc, VALUE *argv, VALUE self)
 {


### PR DESCRIPTION
The documentation for BigDecimal#div currently doesn't show up at the right place:

```
$ ri BigDecimal.div
BigDecimal.div

(from ruby site)
------------------------------------------------------------------------------
  div(p1, p2 = v2)
```

Instead it appears under BigDecimal#quo or the / operator.

The PR moves the existing docs to #div, and refers to it from #/ and #quo.
It also fixes some errors, clarifies the behavior and adds some examples.