### PR TITLE
Fix error message for Rational#to_d with invalid precision

### DIFF
--- a/lib/bigdecimal/util.rb
+++ b/lib/bigdecimal/util.rb
@@ -129,7 +129,7 @@ class Rational < Numeric
   #   # => 0.314e1
   def to_d(precision)
     if precision <= 0
-      raise ArgumentError, "negative precision"
+      raise ArgumentError, "argument must be positive"
     end
     num = self.numerator
     BigDecimal(num).div(self.denominator, precision)


### PR DESCRIPTION
Make the error message for nonpositive precision in Rational#to_d
match with the error raised by BigDecimal.new in that case.

Current behavior:

``` ruby
require "bigdecimal"
require "bigdecimal/util"

r = 22/7r  # => (22/7)

BigDecimal(r, -1) rescue $!  # => #<ArgumentError: argument must be positive>
r.to_d(-1)        rescue $!  # => #<ArgumentError: negative precision>
```

Note also that the condition (`precision <= 0`) does not match the current error message.