### PR TITLE
Fix setting of default precision for Float#to_d

### DIFF
--- a/lib/bigdecimal/util.rb
+++ b/lib/bigdecimal/util.rb
@@ -42,8 +42,8 @@ class Float < Numeric
   #
   # See also BigDecimal::new.
   #
-  def to_d(precision=nil)
-    BigDecimal(self, precision || Float::DIG)
+  def to_d(precision=Float::DIG)
+    BigDecimal(self, precision)
   end
 end
 


### PR DESCRIPTION
Simplify setting of the default value for the precision argument
of Float#to_d. This also synchronizes the handling of falsy precision
with the behavior of BigDecimal.new (which raises TypeError).

Current behavior:

``` ruby
require "bigdecimal"
require "bigdecimal/util"

BigDecimal(0.3, nil)   rescue $!  # => #<TypeError: no implicit conversion from nil to integer>
BigDecimal(0.3, false) rescue $!  # => #<TypeError: no implicit conversion of false into Integer>
0.3.to_d(nil)                     # => 0.3e0
0.3.to_d(false)                   # => 0.3e0
```

But maybe there's a reason why `#to_d` behaves like that, which I just don't see.