### PR TITLE
Let Rational#to_d use BigDecimal() and accept zero precision

### DIFF
--- a/lib/bigdecimal/util.rb
+++ b/lib/bigdecimal/util.rb
@@ -126,9 +126,6 @@ class Rational < Numeric
   #   r.to_d(3)
   #   # => 0.314e1
   def to_d(precision)
-    if precision <= 0
-      raise ArgumentError, "negative precision"
-    end
     BigDecimal(self, precision)
   end
 end

--- a/lib/bigdecimal/util.rb
+++ b/lib/bigdecimal/util.rb
@@ -119,9 +119,7 @@ class Rational < Numeric
   # Converts a Rational to a BigDecimal.
   #
   # The required +precision+ parameter is used to determine the amount of
-  # significant digits for the result. See BigDecimal#div for more information,
-  # as it is used along with the #denominator and the +precision+ for
-  # parameters.
+  # significant digits for the result. See BigDecimal::new for more information.
   #
   #   r = (22/7.0).to_r
   #   # => (7077085128725065/2251799813685248)
@@ -131,7 +129,6 @@ class Rational < Numeric
     if precision <= 0
       raise ArgumentError, "negative precision"
     end
-    num = self.numerator
-    BigDecimal(num).div(self.denominator, precision)
+    BigDecimal(self, precision)
   end
 end

--- a/test/test_bigdecimal_util.rb
+++ b/test/test_bigdecimal_util.rb
@@ -42,7 +42,7 @@ class TestBigDecimalUtil < Test::Unit::TestCase
   end
 
   def test_Rational_to_d_with_zero_precision
-    assert_raise(ArgumentError) { 355.quo(113).to_d(0) }
+    assert_equal(BigDecimal(355.quo(113), 0), 355.quo(113).to_d(0))
   end
 
   def test_Rational_to_d_with_negative_precision


### PR DESCRIPTION
1. Rational#to_d behaves slightly differently from BigDecimal(rational_num).

Current behavior for zero precision:

``` ruby
# for Float the behavior is the same:
BigDecimal(0.3, 0)       # => 0.299999999999999988897769753748434596e0
0.3.to_d(0)              # => 0.299999999999999988897769753748434596e0

# yet not for Rational:
BigDecimal(22/7r, 0)     # => 0.3142857142857142857e1
22/7r.to_d(0) rescue $!  # => #<ArgumentError: negative precision>
```

Since zero precision is accepted for floats, it seems it should also be accepted for rationals.

2. All other `#to_d` methods defined in util.rb are simple wrappers around BigDecimal(), but in the case of rationals, the conversion is done by `#to_d` itself, using BigDecimal#div. IMO the conversion should be delegated to BigDecimal() instead, which also does argument checking.

The patch changes Rational#to_d to use BigDecimal() and removes the (duplicate) argument checking, thereby now also allowing zero precision.
