### PR TITLE
Fix error message for precision argument

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2029,6 +2029,7 @@ BigDecimal_to_s(int argc, VALUE *argv, VALUE self)
     char  *psz;
     char   ch;
     size_t nc, mc = 0;
+    SIGNED_VALUE m;
     VALUE  f;
 
     GUARD_OBJ(vp, GetVpValue(self, 1));
@@ -2059,7 +2060,11 @@ BigDecimal_to_s(int argc, VALUE *argv, VALUE self)
 	    }
 	}
 	else {
-	    mc = (size_t)GetPositiveInt(f);
+	    m = NUM2INT(f);
+	    if (m <= 0) {
+		rb_raise(rb_eArgError, "argument must be positive");
+	    }
+	    mc = (size_t)m;
 	}
     }
     if (fmt) {

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -643,7 +643,7 @@ GetAddSubPrec(Real *a, Real *b)
 }
 
 static SIGNED_VALUE
-GetPositiveInt(VALUE v)
+GetPrecisionInt(VALUE v)
 {
     SIGNED_VALUE n;
     n = NUM2INT(v);
@@ -1568,7 +1568,7 @@ BigDecimal_div2(VALUE self, VALUE b, VALUE n)
     }
 
     /* div in BigDecimal sense */
-    ix = GetPositiveInt(n);
+    ix = GetPrecisionInt(n);
     if (ix == 0) {
         return BigDecimal_div(self, b);
     }
@@ -1637,7 +1637,7 @@ BigDecimal_add2(VALUE self, VALUE b, VALUE n)
 {
     ENTER(2);
     Real *cv;
-    SIGNED_VALUE mx = GetPositiveInt(n);
+    SIGNED_VALUE mx = GetPrecisionInt(n);
     if (mx == 0) return BigDecimal_add(self, b);
     else {
 	size_t pl = VpSetPrecLimit(0);
@@ -1667,7 +1667,7 @@ BigDecimal_sub2(VALUE self, VALUE b, VALUE n)
 {
     ENTER(2);
     Real *cv;
-    SIGNED_VALUE mx = GetPositiveInt(n);
+    SIGNED_VALUE mx = GetPrecisionInt(n);
     if (mx == 0) return BigDecimal_sub(self, b);
     else {
 	size_t pl = VpSetPrecLimit(0);
@@ -1685,7 +1685,7 @@ BigDecimal_mult2(VALUE self, VALUE b, VALUE n)
 {
     ENTER(2);
     Real *cv;
-    SIGNED_VALUE mx = GetPositiveInt(n);
+    SIGNED_VALUE mx = GetPrecisionInt(n);
     if (mx == 0) return BigDecimal_mult(self, b);
     else {
 	size_t pl = VpSetPrecLimit(0);
@@ -1739,7 +1739,7 @@ BigDecimal_sqrt(VALUE self, VALUE nFig)
     GUARD_OBJ(a, GetVpValue(self, 1));
     mx = a->Prec * (VpBaseFig() + 1);
 
-    n = GetPositiveInt(nFig) + VpDblFig() + BASE_FIG;
+    n = GetPrecisionInt(nFig) + VpDblFig() + BASE_FIG;
     if (mx <= n) mx = n;
     GUARD_OBJ(c, VpCreateRbObject(mx, "0"));
     VpSqrt(c, a);
@@ -2640,7 +2640,7 @@ BigDecimal_new(int argc, VALUE *argv)
         mf = 0;
     }
     else {
-        mf = GetPositiveInt(nFig);
+        mf = GetPrecisionInt(nFig);
     }
 
     switch (TYPE(iniValue)) {

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -648,7 +648,7 @@ GetPositiveInt(VALUE v)
     SIGNED_VALUE n;
     n = NUM2INT(v);
     if (n < 0) {
-	rb_raise(rb_eArgError, "argument must be positive");
+	rb_raise(rb_eArgError, "negative precision");
     }
     return n;
 }

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2022,8 +2022,8 @@ static VALUE
 BigDecimal_to_s(int argc, VALUE *argv, VALUE self)
 {
     ENTER(5);
-    int   fmt = 0;   /* 0:E format */
-    int   fPlus = 0; /* =0:default,=1: set ' ' before digits ,set '+' before digits. */
+    int   fmt = 0;   /* 0: E format, 1: F format */
+    int   fPlus = 0; /* 0: default, 1: set ' ' before digits, 2: set '+' before digits. */
     Real  *vp;
     volatile VALUE str;
     char  *psz;
@@ -5350,7 +5350,7 @@ VpSzMantissa(Real *a,char *psz)
 
 VP_EXPORT int
 VpToSpecialString(Real *a,char *psz,int fPlus)
-    /* fPlus =0:default, =1: set ' ' before digits , =2: set '+' before digits. */
+/* fPlus = 0: default, 1: set ' ' before digits, 2: set '+' before digits. */
 {
     if (VpIsNaN(a)) {
 	sprintf(psz,SZ_NaN);
@@ -5385,7 +5385,7 @@ VpToSpecialString(Real *a,char *psz,int fPlus)
 
 VP_EXPORT void
 VpToString(Real *a, char *psz, size_t fFmt, int fPlus)
-/* fPlus =0:default, =1: set ' ' before digits , =2:set '+' before digits. */
+/* fPlus = 0: default, 1: set ' ' before digits, 2: set '+' before digits. */
 {
     size_t i, n, ZeroSup;
     BDIGIT shift, m, e, nn;
@@ -5433,7 +5433,7 @@ VpToString(Real *a, char *psz, size_t fFmt, int fPlus)
 
 VP_EXPORT void
 VpToFString(Real *a, char *psz, size_t fFmt, int fPlus)
-/* fPlus =0:default,=1: set ' ' before digits ,set '+' before digits. */
+/* fPlus = 0: default, 1: set ' ' before digits, 2: set '+' before digits. */
 {
     size_t i, n;
     BDIGIT m, e, nn;


### PR DESCRIPTION
Current behavior:

``` ruby
BigDecimal(-0.2, 0)              # => -0.200000000000000011102230246251565404e0
BigDecimal(-0.2, -1)  rescue $!  # => #<ArgumentError: argument must be positive>

d = (22/7r).to_d(9)

d.div(2, 3)              # => 0.157e1
d.div(2, 0)              # => 0.157142857e1
d.div(2, -1)  rescue $!  # => #<ArgumentError: argument must be positive>
```

The error message could be more descriptive (which argument?), furthermore, the message is wrong, since precisions can also be 0. So, something like e.g. "negative precision" would be better. Problem: the exception is raised by `GetPositiveInt()`, which is also used by BigDecimal#to_s:

``` ruby
d.to_s(3)                # => "0.314 285 714e1"
d.to_s(0)                # => "0.314285714e1"
d.to_s(-1)  rescue $!    # => #<ArgumentError: argument must be positive>
```
In this case, the argument is _not_ a precision. So, simply changing the message would not work (and the very general "negative argument" would be misleading for the cases with more than one numeric argument).

The PR separates argument checking for to_s from the other cases that use GetPositiveInt(), allowing for a different error message. It also disallows value 0 for BigDecimal#to_s, which doesn't make sense for grouping of digits, and which is simply ignored currently.

The new behavior would be

``` ruby
d.to_s(3)                # => "0.314 285 714e1"
d.to_s(0)   rescue $!    # => #<ArgumentError: argument must be positive>
d.to_s(-1)  rescue $!    # => #<ArgumentError: argument must be positive>

BigDecimal(-0.2, 0)              # => -0.200000000000000011102230246251565404e0
BigDecimal(-0.2, -1)  rescue $!  # => #<ArgumentError: negative precision>

d.div(2, 3)              # => 0.157e1
d.div(2, 0)              # => 0.157142857e1
d.div(2, -1)  rescue $!  # => #<ArgumentError: negative precision>
```

I verified that all other use cases for GetPositiveInt() are for precision (number of significant digits), namely ::new, div, add, sub, mult, sqrt.

I am looking forward to any feedback, and have no problems with modifying the PR if necessary (coding style, adding tests, etc.).
This is more or less my first "project" for learning about Ruby's C API, so thanks for your patience.