### PR TITLE
Define RUBY_NO_OLD_COMPATIBILITY

### DIFF
--- a/ext/bigdecimal/bigdecimal.h
+++ b/ext/bigdecimal/bigdecimal.h
@@ -9,6 +9,8 @@
 #ifndef  RUBY_BIG_DECIMAL_H
 #define  RUBY_BIG_DECIMAL_H 1
 
+#define RUBY_NO_OLD_COMPATIBILITY
+
 #include "ruby/ruby.h"
 #include <float.h>
 

--- a/ext/bigdecimal/extconf.rb
+++ b/ext/bigdecimal/extconf.rb
@@ -15,12 +15,3 @@ have_func("rb_array_const_ptr", "ruby.h")
 have_func("rb_sym2str", "ruby.h")
 
 create_makefile('bigdecimal')
-
-# Add additional dependencies
-open('Makefile', 'a') do |io|
-  if RUBY_VERSION >= '2.4'
-    io.puts <<-MAKEFILE
-bigdecimal.o: $(hdrdir)/ruby/backward.h
-    MAKEFILE
-  end
-end


### PR DESCRIPTION
Get rid of including ruby/backward.h which is not used in
BigDecimal.
And the rule directly appended to Makefile does not work with
nmake, because the suffix .o is not replaced with .obj.