### PR TITLE
Added cross compilation task using rake-compiler-dock

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
-require "bundler/gem_tasks"
+require "bundler"
+Bundler::GemHelper.install_tasks
+
 require "rake"
 require "rake/extensiontask"
 require "rake/testtask"

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,21 @@ require "rake"
 require "rake/extensiontask"
 require "rake/testtask"
 
-Rake::ExtensionTask.new('bigdecimal')
+spec = eval(File.read('bigdecimal.gemspec'))
+Rake::ExtensionTask.new('bigdecimal', spec) do |ext|
+  ext.lib_dir = File.join(*['lib', ENV['FAT_DIR']].compact)
+  ext.cross_compile = true
+  ext.cross_platform = %w[x86-mingw32 x64-mingw32]
+  ext.cross_compiling do |s|
+    s.files.concat ["lib/2.2/bigdecimal.so", "lib/2.3/bigdecimal.so", "lib/2.4/bigdecimal.so"]
+  end
+end
+
+desc "Compile binaries for mingw platform using rake-compiler-dock"
+task 'build:mingw' do
+  require 'rake_compiler_dock'
+  RakeCompilerDock.sh "bundle && rake cross native gem RUBY_CC_VERSION=2.2.2:2.3.0:2.4.0"
+end
 
 Rake::TestTask.new do |t|
   t.libs << 'test/lib'

--- a/bigdecimal.gemspec
+++ b/bigdecimal.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "rake-compiler", "~> 0.9"
+  s.add_development_dependency "rake-compiler-dock", ">= 0.6.1"
   s.add_development_dependency "minitest", "~> 4.7.5"
   s.add_development_dependency "pry"
 end

--- a/lib/bigdecimal.rb
+++ b/lib/bigdecimal.rb
@@ -1,0 +1,5 @@
+begin
+  require "#{RUBY_VERSION[/\d+\.\d+/]}/bigdecimal.so"
+rescue LoadError
+  require 'bigdecimal.so'
+end


### PR DESCRIPTION
Hi, I added `build:mingw` task for mingw platforms. It makes that we can provide precompiled gem for mingw platform. It helps to use the latest version of bigdecimal for Windows users without devkit.

@mrkn How do you think about this?