### PR TITLE
Relax a version constraint on rake-compiler

### DIFF
--- a/bigdecimal.gemspec
+++ b/bigdecimal.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   ]
 
   s.add_development_dependency "rake", "~> 10.0"
-  s.add_development_dependency "rake-compiler", "~> 0.9"
+  s.add_development_dependency "rake-compiler", ">= 0.9"
   s.add_development_dependency "rake-compiler-dock", ">= 0.6.1"
   s.add_development_dependency "minitest", "~> 4.7.5"
   s.add_development_dependency "pry"


### PR DESCRIPTION
rake-compiler v1.0 was released on June 20, 2016.
This commit will allow developers to use rake-compiler v1.0.