### PR TITLE
Deprecate BigDecimal#clone and #dup

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2630,6 +2630,20 @@ BigDecimal_initialize_copy(VALUE self, VALUE other)
     return self;
 }
 
+static VALUE
+BigDecimal_clone(VALUE self)
+{
+  rb_warning("BigDecimal#clone is deprecated.");
+  return rb_call_super(0, NULL);
+}
+
+static VALUE
+BigDecimal_dup(VALUE self)
+{
+  rb_warning("BigDecimal#dup is deprecated.");
+  return rb_call_super(0, NULL);
+}
+
 static Real *
 BigDecimal_new(int argc, VALUE *argv)
 {
@@ -3413,7 +3427,8 @@ Init_bigdecimal(void)
     rb_define_method(rb_cBigDecimal, "modulo", BigDecimal_mod, 1);
     rb_define_method(rb_cBigDecimal, "remainder", BigDecimal_remainder, 1);
     rb_define_method(rb_cBigDecimal, "divmod", BigDecimal_divmod, 1);
-    /* rb_define_method(rb_cBigDecimal, "dup", BigDecimal_dup, 0); */
+    rb_define_method(rb_cBigDecimal, "clone", BigDecimal_clone, 0);
+    rb_define_method(rb_cBigDecimal, "dup", BigDecimal_dup, 0);
     rb_define_method(rb_cBigDecimal, "to_f", BigDecimal_to_f, 0);
     rb_define_method(rb_cBigDecimal, "abs", BigDecimal_abs, 0);
     rb_define_method(rb_cBigDecimal, "sqrt", BigDecimal_sqrt, 1);

--- a/test/test_bigdecimal.rb
+++ b/test/test_bigdecimal.rb
@@ -1764,19 +1764,29 @@ class TestBigDecimal < Test::Unit::TestCase
     EOS
   end
 
+  def test_clone
+    assert_warning(/BigDecimal#clone is deprecated/) do
+      BigDecimal(0).clone
+    end
+  end
+
   def test_dup
-    [1, -1, 2**100, -2**100].each do |i|
-      x = BigDecimal(i)
-      assert_equal(x, x.dup)
+    assert_warning(/BigDecimal#dup is deprecated/) do
+      [1, -1, 2**100, -2**100].each do |i|
+        x = BigDecimal(i)
+        assert_equal(x, x.dup)
+      end
     end
   end
 
   def test_dup_subclass
-    c = Class.new(BigDecimal)
-    x = c.new(1)
-    y = x.dup
-    assert_equal(1, y)
-    assert_kind_of(c, y)
+    assert_warning(/BigDecimal#dup is deprecated/) do
+      c = Class.new(BigDecimal)
+      x = c.new(1)
+      y = x.dup
+      assert_equal(1, y)
+      assert_kind_of(c, y)
+    end
   end
 
   def test_to_d


### PR DESCRIPTION
For removing clone and dup instance methods in the future [#84],
we first deprecate them during Ruby 2.5 period.