### PR TITLE
Deprecate BigDecimal.new

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -392,7 +392,7 @@ BigDecimal_hash(VALUE self)
  *
  * Method used to provide marshalling support.
  *
- *      inf = BigDecimal.new('Infinity')
+ *      inf = BigDecimal('Infinity')
  *        #=> Infinity
  *      BigDecimal._load(inf._dump)
  *        #=> Infinity
@@ -875,7 +875,7 @@ BigDecimal_to_r(VALUE self)
  * be coerced into a BigDecimal value.
  *
  * e.g.
- *   a = BigDecimal.new("1.0")
+ *   a = BigDecimal("1.0")
  *   b = a / 2.0 #=> 0.5
  *
  * Note that coercing a String to a BigDecimal is not supported by default;
@@ -1164,7 +1164,7 @@ BigDecimal_comp(VALUE self, VALUE r)
  *
  * Values may be coerced to perform the comparison:
  *
- *   BigDecimal.new('1.0') == 1.0  #=> true
+ *   BigDecimal('1.0') == 1.0  #=> true
  */
 static VALUE
 BigDecimal_eq(VALUE self, VALUE r)
@@ -1526,8 +1526,8 @@ BigDecimal_remainder(VALUE self, VALUE r) /* remainder */
  *
  *   require 'bigdecimal'
  *
- *   a = BigDecimal.new("42")
- *   b = BigDecimal.new("9")
+ *   a = BigDecimal("42")
+ *   b = BigDecimal("9")
  *
  *   q, m = a.divmod(b)
  *
@@ -2011,13 +2011,13 @@ BigDecimal_ceil(int argc, VALUE *argv, VALUE self)
  *
  * Examples:
  *
- *   BigDecimal.new('-123.45678901234567890').to_s('5F')
+ *   BigDecimal('-123.45678901234567890').to_s('5F')
  *     #=> '-123.45678 90123 45678 9'
  *
- *   BigDecimal.new('123.45678901234567890').to_s('+8F')
+ *   BigDecimal('123.45678901234567890').to_s('+8F')
  *     #=> '+123.45678901 23456789'
  *
- *   BigDecimal.new('123.45678901234567890').to_s(' F')
+ *   BigDecimal('123.45678901234567890').to_s(' F')
  *     #=> ' 123.4567890123456789'
  */
 static VALUE
@@ -2163,7 +2163,7 @@ BigDecimal_exponent(VALUE self)
 /* Returns debugging information about the value as a string of comma-separated
  * values in angle brackets with a leading #:
  *
- *   BigDecimal.new("1234.5678").inspect
+ *   BigDecimal("1234.5678").inspect
  *     #=> "0.12345678e4"
  *
  * The first part is the address, the second is the value as a string, and
@@ -2776,9 +2776,9 @@ BigDecimal_sign(VALUE self)
  *       BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
  *       BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
  *
- *       BigDecimal.new(BigDecimal('Infinity'))
- *       BigDecimal.new(BigDecimal('-Infinity'))
- *       BigDecimal(BigDecimal.new('NaN'))
+ *       BigDecimal(BigDecimal('Infinity'))
+ *       BigDecimal(BigDecimal('-Infinity'))
+ *       BigDecimal(BigDecimal('NaN'))
  *     end
  *
  * For use with the BigDecimal::EXCEPTION_*
@@ -3165,15 +3165,15 @@ get_vp_value:
  *
  *   require 'bigdecimal'
  *
- *   sum = BigDecimal.new("0")
+ *   sum = BigDecimal("0")
  *   10_000.times do
- *     sum = sum + BigDecimal.new("0.0001")
+ *     sum = sum + BigDecimal("0.0001")
  *   end
  *   print sum #=> 0.1E1
  *
  * Similarly:
  *
- *	(BigDecimal.new("1.2") - BigDecimal("1.0")) == BigDecimal("0.2") #=> true
+ *	(BigDecimal("1.2") - BigDecimal("1.0")) == BigDecimal("0.2") #=> true
  *
  *	(1.2 - 1.0) == 0.2 #=> false
  *
@@ -3187,8 +3187,8 @@ get_vp_value:
  * BigDecimal sometimes needs to return infinity, for example if you divide
  * a value by zero.
  *
- *	BigDecimal.new("1.0") / BigDecimal.new("0.0")  #=> Infinity
- *	BigDecimal.new("-1.0") / BigDecimal.new("0.0")  #=> -Infinity
+ *	BigDecimal("1.0") / BigDecimal("0.0")  #=> Infinity
+ *	BigDecimal("-1.0") / BigDecimal("0.0")  #=> -Infinity
  *
  * You can represent infinite numbers to BigDecimal using the strings
  * <code>'Infinity'</code>, <code>'+Infinity'</code> and
@@ -3201,13 +3201,13 @@ get_vp_value:
  *
  * Example:
  *
- *	BigDecimal.new("0.0") / BigDecimal.new("0.0") #=> NaN
+ *	BigDecimal("0.0") / BigDecimal("0.0") #=> NaN
  *
  * You can also create undefined values.
  *
  * NaN is never considered to be the same as any other value, even NaN itself:
  *
- *	n = BigDecimal.new('NaN')
+ *	n = BigDecimal('NaN')
  *	n == 0.0 #=> false
  *	n == n #=> false
  *
@@ -3220,11 +3220,11 @@ get_vp_value:
  * If the value which is too small to be represented is negative, a BigDecimal
  * value of negative zero is returned.
  *
- *	BigDecimal.new("1.0") / BigDecimal.new("-Infinity") #=> -0.0
+ *	BigDecimal("1.0") / BigDecimal("-Infinity") #=> -0.0
  *
  * If the value is positive, a value of positive zero is returned.
  *
- *	BigDecimal.new("1.0") / BigDecimal.new("Infinity") #=> 0.0
+ *	BigDecimal("1.0") / BigDecimal("Infinity") #=> 0.0
  *
  * (See BigDecimal.mode for how to specify limits of precision.)
  *

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2595,6 +2595,13 @@ static Real *BigDecimal_new(int argc, VALUE *argv);
  *                 value is omitted, this exception is raised.
  */
 static VALUE
+BigDecimal_s_new(int argc, VALUE *argv, VALUE self)
+{
+  rb_warning("BigDecimal.new is deprecated");
+  return rb_call_super(argc, argv);
+}
+
+static VALUE
 BigDecimal_initialize(int argc, VALUE *argv, VALUE self)
 {
     ENTER(1);
@@ -3279,6 +3286,7 @@ Init_bigdecimal(void)
     rb_define_global_function("BigDecimal", BigDecimal_global_new, -1);
 
     /* Class methods */
+    rb_define_singleton_method(rb_cBigDecimal, "new", BigDecimal_s_new, -1);
     rb_define_singleton_method(rb_cBigDecimal, "mode", BigDecimal_mode, -1);
     rb_define_singleton_method(rb_cBigDecimal, "limit", BigDecimal_limit, -1);
     rb_define_singleton_method(rb_cBigDecimal, "double_fig", BigDecimal_double_fig, 0);

--- a/lib/bigdecimal/math.rb
+++ b/lib/bigdecimal/math.rb
@@ -37,7 +37,7 @@ module BigMath
   # Computes the square root of +decimal+ to the specified number of digits of
   # precision, +numeric+.
   #
-  #   BigMath.sqrt(BigDecimal.new('2'), 16).to_s
+  #   BigMath.sqrt(BigDecimal('2'), 16).to_s
   #   #=> "0.1414213562373095048801688724e1"
   #
   def sqrt(x, prec)
@@ -140,7 +140,7 @@ module BigMath
   #
   # If +decimal+ is NaN, returns NaN.
   #
-  #   BigMath.atan(BigDecimal.new('-1'), 16).to_s
+  #   BigMath.atan(BigDecimal('-1'), 16).to_s
   #   #=> "-0.785398163397448309615660845819878471907514682065e0"
   #
   def atan(x, prec)

--- a/lib/bigdecimal/util.rb
+++ b/lib/bigdecimal/util.rb
@@ -83,7 +83,7 @@ class BigDecimal < Numeric
   #
   #     require 'bigdecimal/util'
   #
-  #     d = BigDecimal.new("3.14")
+  #     d = BigDecimal("3.14")
   #     d.to_digits                  # => "3.14"
   #
   def to_digits
@@ -103,7 +103,7 @@ class BigDecimal < Numeric
   #
   #     require 'bigdecimal/util'
   #
-  #     d = BigDecimal.new("3.14")
+  #     d = BigDecimal("3.14")
   #     d.to_d                       # => 0.314e1
   #
   def to_d

--- a/sample/linear.rb
+++ b/sample/linear.rb
@@ -28,8 +28,8 @@ def rd_order(na)
 end
 
 na   = ARGV.size
-zero = BigDecimal.new("0.0")
-one  = BigDecimal.new("1.0")
+zero = BigDecimal("0.0")
+one  = BigDecimal("1.0")
 
 while (n=rd_order(na))>0
   a = []
@@ -37,27 +37,28 @@ while (n=rd_order(na))>0
   b = []
   if na <= 0
      # Read data from console.
-     printf("\nEnter coefficient matrix element A[i,j]\n");
+     printf("\nEnter coefficient matrix element A[i,j]\n")
      for i in 0...n do
        for j in 0...n do
          printf("A[%d,%d]? ",i,j); s = ARGF.gets
-         a  << BigDecimal.new(s);
-         as << BigDecimal.new(s);
+         a  << BigDecimal(s)
+         as << BigDecimal(s)
        end
-       printf("Contatant vector element b[%d] ? ",i); b << BigDecimal.new(ARGF.gets);
+       printf("Contatant vector element b[%d] ? ",i)
+       b << BigDecimal(ARGF.gets)
      end
   else
      # Read data from specified file.
-     printf("Coefficient matrix and constant vector.\n");
+     printf("Coefficient matrix and constant vector.\n")
      for i in 0...n do
        s = ARGF.gets
        printf("%d) %s",i,s)
        s = s.split
        for j in 0...n do
-         a  << BigDecimal.new(s[j]);
-         as << BigDecimal.new(s[j]);
+         a  << BigDecimal(s[j])
+         as << BigDecimal(s[j])
        end
-       b << BigDecimal.new(s[n]);
+       b << BigDecimal(s[n])
      end
   end
   x = lusolve(a,b,ludecomp(a,n,zero,one),zero)

--- a/sample/nlsolve.rb
+++ b/sample/nlsolve.rb
@@ -12,11 +12,11 @@ include Newton
 
 class Function # :nodoc: all
   def initialize()
-    @zero = BigDecimal.new("0.0")
-    @one  = BigDecimal.new("1.0")
-    @two  = BigDecimal.new("2.0")
-    @ten  = BigDecimal.new("10.0")
-    @eps  = BigDecimal.new("1.0e-16")
+    @zero = BigDecimal("0.0")
+    @one  = BigDecimal("1.0")
+    @two  = BigDecimal("2.0")
+    @ten  = BigDecimal("10.0")
+    @eps  = BigDecimal("1.0e-16")
   end
   def zero;@zero;end
   def one ;@one ;end

--- a/test/test_bigdecimal.rb
+++ b/test/test_bigdecimal.rb
@@ -130,6 +130,9 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_new
+  end
+
+  def test_new
     assert_equal(1, BigDecimal.new("1"))
     assert_equal(1, BigDecimal.new("1", 1))
     assert_equal(1, BigDecimal.new(" 1 "))
@@ -147,43 +150,43 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_new_with_integer
-    assert_equal(BigDecimal("1"), BigDecimal.new(1))
-    assert_equal(BigDecimal("-1"), BigDecimal.new(-1))
-    assert_equal(BigDecimal((2**100).to_s), BigDecimal.new(2**100))
-    assert_equal(BigDecimal((-2**100).to_s), BigDecimal.new(-2**100))
+    assert_equal(BigDecimal("1"), BigDecimal(1))
+    assert_equal(BigDecimal("-1"), BigDecimal(-1))
+    assert_equal(BigDecimal((2**100).to_s), BigDecimal(2**100))
+    assert_equal(BigDecimal((-2**100).to_s), BigDecimal(-2**100))
   end
 
   def test_new_with_rational
-    assert_equal(BigDecimal("0.333333333333333333333"), BigDecimal.new(1.quo(3), 21))
-    assert_equal(BigDecimal("-0.333333333333333333333"), BigDecimal.new(-1.quo(3), 21))
-    assert_raise(ArgumentError) { BigDecimal.new(1.quo(3)) }
+    assert_equal(BigDecimal("0.333333333333333333333"), BigDecimal(1.quo(3), 21))
+    assert_equal(BigDecimal("-0.333333333333333333333"), BigDecimal(-1.quo(3), 21))
+    assert_raise(ArgumentError) { BigDecimal(1.quo(3)) }
   end
 
   def test_new_with_float
     assert_equal(BigDecimal("0.1235"), BigDecimal(0.1234567, 4))
     assert_equal(BigDecimal("-0.1235"), BigDecimal(-0.1234567, 4))
-    assert_raise(ArgumentError) { BigDecimal.new(0.1) }
-    assert_raise(ArgumentError) { BigDecimal.new(0.1, Float::DIG + 2) }
-    assert_nothing_raised { BigDecimal.new(0.1, Float::DIG + 1) }
+    assert_raise(ArgumentError) { BigDecimal(0.1) }
+    assert_raise(ArgumentError) { BigDecimal(0.1, Float::DIG + 2) }
+    assert_nothing_raised { BigDecimal(0.1, Float::DIG + 1) }
   end
 
   def test_new_with_big_decimal
-    assert_equal(BigDecimal(1), BigDecimal.new(BigDecimal(1)))
-    assert_equal(BigDecimal('+0'), BigDecimal.new(BigDecimal('+0')))
-    assert_equal(BigDecimal('-0'), BigDecimal.new(BigDecimal('-0')))
+    assert_equal(BigDecimal(1), BigDecimal(BigDecimal(1)))
+    assert_equal(BigDecimal('+0'), BigDecimal(BigDecimal('+0')))
+    assert_equal(BigDecimal('-0'), BigDecimal(BigDecimal('-0')))
     BigDecimal.save_exception_mode do
       BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
       BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-      assert_positive_infinite(BigDecimal.new(BigDecimal('Infinity')))
-      assert_negative_infinite(BigDecimal.new(BigDecimal('-Infinity')))
-      assert_nan(BigDecimal(BigDecimal.new('NaN')))
+      assert_positive_infinite(BigDecimal(BigDecimal('Infinity')))
+      assert_negative_infinite(BigDecimal(BigDecimal('-Infinity')))
+      assert_nan(BigDecimal(BigDecimal('NaN')))
     end
   end
 
   def test_new_with_tainted_string
     Thread.new {
       $SAFE = 1
-      BigDecimal.new('1'.taint)
+      BigDecimal('1'.taint)
     }.join
   end
 
@@ -285,16 +288,16 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_exception_nan
-    _test_mode(BigDecimal::EXCEPTION_NaN) { BigDecimal.new("NaN") }
+    _test_mode(BigDecimal::EXCEPTION_NaN) { BigDecimal("NaN") }
   end
 
   def test_exception_infinity
-    _test_mode(BigDecimal::EXCEPTION_INFINITY) { BigDecimal.new("Infinity") }
+    _test_mode(BigDecimal::EXCEPTION_INFINITY) { BigDecimal("Infinity") }
   end
 
   def test_exception_underflow
     _test_mode(BigDecimal::EXCEPTION_UNDERFLOW) do
-      x = BigDecimal.new("0.1")
+      x = BigDecimal("0.1")
       100.times do
         x *= x
       end
@@ -303,7 +306,7 @@ class TestBigDecimal < Test::Unit::TestCase
 
   def test_exception_overflow
     _test_mode(BigDecimal::EXCEPTION_OVERFLOW) do
-      x = BigDecimal.new("10")
+      x = BigDecimal("10")
       100.times do
         x *= x
       end
@@ -312,17 +315,17 @@ class TestBigDecimal < Test::Unit::TestCase
 
   def test_exception_zerodivide
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
-    _test_mode(BigDecimal::EXCEPTION_ZERODIVIDE) { 1 / BigDecimal.new("0") }
-    _test_mode(BigDecimal::EXCEPTION_ZERODIVIDE) { -1 / BigDecimal.new("0") }
+    _test_mode(BigDecimal::EXCEPTION_ZERODIVIDE) { 1 / BigDecimal("0") }
+    _test_mode(BigDecimal::EXCEPTION_ZERODIVIDE) { -1 / BigDecimal("0") }
   end
 
   def test_round_up
-    n4 = BigDecimal.new("4") # n4 / 9 = 0.44444...
-    n5 = BigDecimal.new("5") # n5 / 9 = 0.55555...
-    n6 = BigDecimal.new("6") # n6 / 9 = 0.66666...
+    n4 = BigDecimal("4") # n4 / 9 = 0.44444...
+    n5 = BigDecimal("5") # n5 / 9 = 0.55555...
+    n6 = BigDecimal("6") # n6 / 9 = 0.66666...
     m4, m5, m6 = -n4, -n5, -n6
-    n2h = BigDecimal.new("2.5")
-    n3h = BigDecimal.new("3.5")
+    n2h = BigDecimal("2.5")
+    n3h = BigDecimal("3.5")
     m2h, m3h = -n2h, -n3h
 
     BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_UP)
@@ -414,25 +417,25 @@ class TestBigDecimal < Test::Unit::TestCase
     BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
 
-    assert_equal(true, BigDecimal.new("0").zero?)
-    assert_equal(true, BigDecimal.new("-0").zero?)
-    assert_equal(false, BigDecimal.new("1").zero?)
-    assert_equal(true, BigDecimal.new("0E200000000000000").zero?)
-    assert_equal(false, BigDecimal.new("Infinity").zero?)
-    assert_equal(false, BigDecimal.new("-Infinity").zero?)
-    assert_equal(false, BigDecimal.new("NaN").zero?)
+    assert_equal(true, BigDecimal("0").zero?)
+    assert_equal(true, BigDecimal("-0").zero?)
+    assert_equal(false, BigDecimal("1").zero?)
+    assert_equal(true, BigDecimal("0E200000000000000").zero?)
+    assert_equal(false, BigDecimal("Infinity").zero?)
+    assert_equal(false, BigDecimal("-Infinity").zero?)
+    assert_equal(false, BigDecimal("NaN").zero?)
   end
 
   def test_nonzero_p
     BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
 
-    assert_equal(nil, BigDecimal.new("0").nonzero?)
-    assert_equal(nil, BigDecimal.new("-0").nonzero?)
-    assert_equal(BigDecimal.new("1"), BigDecimal.new("1").nonzero?)
-    assert_positive_infinite(BigDecimal.new("Infinity").nonzero?)
-    assert_negative_infinite(BigDecimal.new("-Infinity").nonzero?)
-    assert_nan(BigDecimal.new("NaN").nonzero?)
+    assert_equal(nil, BigDecimal("0").nonzero?)
+    assert_equal(nil, BigDecimal("-0").nonzero?)
+    assert_equal(BigDecimal("1"), BigDecimal("1").nonzero?)
+    assert_positive_infinite(BigDecimal("Infinity").nonzero?)
+    assert_negative_infinite(BigDecimal("-Infinity").nonzero?)
+    assert_nan(BigDecimal("NaN").nonzero?)
   end
 
   def test_double_fig
@@ -440,8 +443,8 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_cmp
-    n1 = BigDecimal.new("1")
-    n2 = BigDecimal.new("2")
+    n1 = BigDecimal("1")
+    n2 = BigDecimal("2")
     assert_equal( 0, n1 <=> n1)
     assert_equal( 1, n2 <=> n1)
     assert_equal(-1, n1 <=> n2)
@@ -454,16 +457,16 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_operator(n2, :>=, n1)
     assert_operator(n1, :>=, n1)
 
-    assert_operator(BigDecimal.new("-0"), :==, BigDecimal.new("0"))
-    assert_operator(BigDecimal.new("0"), :<, BigDecimal.new("1"))
-    assert_operator(BigDecimal.new("1"), :>, BigDecimal.new("0"))
-    assert_operator(BigDecimal.new("1"), :>, BigDecimal.new("-1"))
-    assert_operator(BigDecimal.new("-1"), :<, BigDecimal.new("1"))
-    assert_operator(BigDecimal.new((2**100).to_s), :>, BigDecimal.new("1"))
-    assert_operator(BigDecimal.new("1"), :<, BigDecimal.new((2**100).to_s))
+    assert_operator(BigDecimal("-0"), :==, BigDecimal("0"))
+    assert_operator(BigDecimal("0"), :<, BigDecimal("1"))
+    assert_operator(BigDecimal("1"), :>, BigDecimal("0"))
+    assert_operator(BigDecimal("1"), :>, BigDecimal("-1"))
+    assert_operator(BigDecimal("-1"), :<, BigDecimal("1"))
+    assert_operator(BigDecimal((2**100).to_s), :>, BigDecimal("1"))
+    assert_operator(BigDecimal("1"), :<, BigDecimal((2**100).to_s))
 
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
-    inf = BigDecimal.new("Infinity")
+    inf = BigDecimal("Infinity")
     assert_operator(inf, :>, 1)
     assert_operator(1, :<, inf)
 
@@ -486,25 +489,25 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_cmp_nan
-    n1 = BigDecimal.new("1")
+    n1 = BigDecimal("1")
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-    assert_equal(nil, BigDecimal.new("NaN") <=> n1)
-    assert_equal(false, BigDecimal.new("NaN") > n1)
-    assert_equal(nil, BigDecimal.new("NaN") <=> BigDecimal.new("NaN"))
-    assert_equal(false, BigDecimal.new("NaN") == BigDecimal.new("NaN"))
+    assert_equal(nil, BigDecimal("NaN") <=> n1)
+    assert_equal(false, BigDecimal("NaN") > n1)
+    assert_equal(nil, BigDecimal("NaN") <=> BigDecimal("NaN"))
+    assert_equal(false, BigDecimal("NaN") == BigDecimal("NaN"))
   end
 
   def test_cmp_failing_coercion
-    n1 = BigDecimal.new("1")
+    n1 = BigDecimal("1")
     assert_equal(nil, n1 <=> nil)
     assert_raise(ArgumentError){n1 > nil}
   end
 
   def test_cmp_coerce
-    n1 = BigDecimal.new("1")
-    n2 = BigDecimal.new("2")
-    o1 = Object.new; def o1.coerce(x); [x, BigDecimal.new("1")]; end
-    o2 = Object.new; def o2.coerce(x); [x, BigDecimal.new("2")]; end
+    n1 = BigDecimal("1")
+    n2 = BigDecimal("2")
+    o1 = Object.new; def o1.coerce(x); [x, BigDecimal("1")]; end
+    o2 = Object.new; def o2.coerce(x); [x, BigDecimal("2")]; end
     assert_equal( 0, n1 <=> o1)
     assert_equal( 1, n2 <=> o1)
     assert_equal(-1, n1 <=> o2)
@@ -524,16 +527,16 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_cmp_bignum
-    assert_operator(BigDecimal.new((2**100).to_s), :==, 2**100)
+    assert_operator(BigDecimal((2**100).to_s), :==, 2**100)
   end
 
   def test_cmp_data
     d = Time.now; def d.coerce(x); [x, x]; end
-    assert_operator(BigDecimal.new((2**100).to_s), :==, d)
+    assert_operator(BigDecimal((2**100).to_s), :==, d)
   end
 
   def test_precs
-    a = BigDecimal.new("1").precs
+    a = BigDecimal("1").precs
     assert_instance_of(Array, a)
     assert_equal(2, a.size)
     assert_kind_of(Integer, a[0])
@@ -542,7 +545,7 @@ class TestBigDecimal < Test::Unit::TestCase
 
   def test_hash
     a = []
-    b = BigDecimal.new("1")
+    b = BigDecimal("1")
     10.times { a << b *= 10 }
     h = {}
     a.each_with_index {|x, i| h[x] = i }
@@ -564,7 +567,7 @@ class TestBigDecimal < Test::Unit::TestCase
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_ZERODIVIDE, false)
 
-    x = BigDecimal.new("0")
+    x = BigDecimal("0")
     assert_equal(true, x.finite?)
     assert_equal(nil, x.infinite?)
     assert_equal(false, x.nan?)
@@ -588,15 +591,15 @@ class TestBigDecimal < Test::Unit::TestCase
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
 
-    x = BigDecimal.new("0")
+    x = BigDecimal("0")
     assert_kind_of(Integer, x.to_i)
     assert_equal(0, x.to_i)
     assert_raise(FloatDomainError){( 1 / x).to_i}
     assert_raise(FloatDomainError){(-1 / x).to_i}
     assert_raise(FloatDomainError) {( 0 / x).to_i}
-    x = BigDecimal.new("1")
+    x = BigDecimal("1")
     assert_equal(1, x.to_i)
-    x = BigDecimal.new((2**100).to_s)
+    x = BigDecimal((2**100).to_s)
     assert_equal(2**100, x.to_i)
   end
 
@@ -605,18 +608,18 @@ class TestBigDecimal < Test::Unit::TestCase
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_ZERODIVIDE, false)
 
-    x = BigDecimal.new("0")
+    x = BigDecimal("0")
     assert_instance_of(Float, x.to_f)
     assert_equal(0.0, x.to_f)
     assert_equal( 1.0 / 0.0, ( 1 / x).to_f)
     assert_equal(-1.0 / 0.0, (-1 / x).to_f)
     assert_nan(( 0 / x).to_f)
-    x = BigDecimal.new("1")
+    x = BigDecimal("1")
     assert_equal(1.0, x.to_f)
-    x = BigDecimal.new((2**100).to_s)
+    x = BigDecimal((2**100).to_s)
     assert_equal((2**100).to_f, x.to_f)
-    x = BigDecimal.new("1" + "0" * 10000)
-    assert_equal(0, BigDecimal.new("-0").to_f)
+    x = BigDecimal("1" + "0" * 10000)
+    assert_equal(0, BigDecimal("-0").to_f)
 
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, true)
     assert_raise(FloatDomainError) { x.to_f }
@@ -664,23 +667,23 @@ class TestBigDecimal < Test::Unit::TestCase
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
 
-    x = BigDecimal.new("0")
+    x = BigDecimal("0")
     assert_kind_of(Rational, x.to_r)
     assert_equal(0, x.to_r)
     assert_raise(FloatDomainError) {( 1 / x).to_r}
     assert_raise(FloatDomainError) {(-1 / x).to_r}
     assert_raise(FloatDomainError) {( 0 / x).to_r}
 
-    assert_equal(1, BigDecimal.new("1").to_r)
-    assert_equal(Rational(3, 2), BigDecimal.new("1.5").to_r)
-    assert_equal((2**100).to_r, BigDecimal.new((2**100).to_s).to_r)
+    assert_equal(1, BigDecimal("1").to_r)
+    assert_equal(Rational(3, 2), BigDecimal("1.5").to_r)
+    assert_equal((2**100).to_r, BigDecimal((2**100).to_s).to_r)
   end
 
   def test_coerce
-    a, b = BigDecimal.new("1").coerce(1.0)
+    a, b = BigDecimal("1").coerce(1.0)
     assert_instance_of(BigDecimal, a)
     assert_instance_of(BigDecimal, b)
-    assert_equal(2, 1 + BigDecimal.new("1"), '[ruby-core:25697]')
+    assert_equal(2, 1 + BigDecimal("1"), '[ruby-core:25697]')
 
     a, b = BigDecimal("1").coerce(1.quo(10))
     assert_equal(BigDecimal("0.1"), a, '[ruby-core:34318]')
@@ -689,12 +692,12 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(BigDecimal("0." + "3"*a.precs[0]), a)
 
     assert_nothing_raised(TypeError, '#7176') do
-      BigDecimal.new('1') + Rational(1)
+      BigDecimal('1') + Rational(1)
     end
   end
 
   def test_uplus
-    x = BigDecimal.new("1")
+    x = BigDecimal("1")
     assert_equal(x, x.send(:+@))
   end
 
@@ -702,26 +705,26 @@ class TestBigDecimal < Test::Unit::TestCase
     BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
 
-    assert_equal(BigDecimal.new("-1"), BigDecimal.new("1").send(:-@))
-    assert_equal(BigDecimal.new("-0"), BigDecimal.new("0").send(:-@))
-    assert_equal(BigDecimal.new("0"), BigDecimal.new("-0").send(:-@))
-    assert_equal(BigDecimal.new("-Infinity"), BigDecimal.new("Infinity").send(:-@))
-    assert_equal(BigDecimal.new("Infinity"), BigDecimal.new("-Infinity").send(:-@))
-    assert_equal(true, BigDecimal.new("NaN").send(:-@).nan?)
+    assert_equal(BigDecimal("-1"), BigDecimal("1").send(:-@))
+    assert_equal(BigDecimal("-0"), BigDecimal("0").send(:-@))
+    assert_equal(BigDecimal("0"), BigDecimal("-0").send(:-@))
+    assert_equal(BigDecimal("-Infinity"), BigDecimal("Infinity").send(:-@))
+    assert_equal(BigDecimal("Infinity"), BigDecimal("-Infinity").send(:-@))
+    assert_equal(true, BigDecimal("NaN").send(:-@).nan?)
   end
 
   def test_add
-    x = BigDecimal.new("1")
-    assert_equal(BigDecimal.new("2"), x + x)
-    assert_equal(1, BigDecimal.new("0") + 1)
+    x = BigDecimal("1")
+    assert_equal(BigDecimal("2"), x + x)
+    assert_equal(1, BigDecimal("0") + 1)
     assert_equal(1, x + 0)
 
-    assert_equal(BigDecimal::SIGN_POSITIVE_ZERO, (BigDecimal.new("0") + 0).sign)
-    assert_equal(BigDecimal::SIGN_POSITIVE_ZERO, (BigDecimal.new("-0") + 0).sign)
-    assert_equal(BigDecimal::SIGN_NEGATIVE_ZERO, (BigDecimal.new("-0") + BigDecimal.new("-0")).sign)
+    assert_equal(BigDecimal::SIGN_POSITIVE_ZERO, (BigDecimal("0") + 0).sign)
+    assert_equal(BigDecimal::SIGN_POSITIVE_ZERO, (BigDecimal("-0") + 0).sign)
+    assert_equal(BigDecimal::SIGN_NEGATIVE_ZERO, (BigDecimal("-0") + BigDecimal("-0")).sign)
 
-    x = BigDecimal.new((2**100).to_s)
-    assert_equal(BigDecimal.new((2**100+1).to_s), x + 1)
+    x = BigDecimal((2**100).to_s)
+    assert_equal(BigDecimal((2**100+1).to_s), x + 1)
 
     BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)
     inf    = BigDecimal("Infinity")
@@ -733,17 +736,17 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_sub
-    x = BigDecimal.new("1")
-    assert_equal(BigDecimal.new("0"), x - x)
-    assert_equal(-1, BigDecimal.new("0") - 1)
+    x = BigDecimal("1")
+    assert_equal(BigDecimal("0"), x - x)
+    assert_equal(-1, BigDecimal("0") - 1)
     assert_equal(1, x - 0)
 
-    assert_equal(BigDecimal::SIGN_POSITIVE_ZERO, (BigDecimal.new("0") - 0).sign)
-    assert_equal(BigDecimal::SIGN_NEGATIVE_ZERO, (BigDecimal.new("-0") - 0).sign)
-    assert_equal(BigDecimal::SIGN_POSITIVE_ZERO, (BigDecimal.new("-0") - BigDecimal.new("-0")).sign)
+    assert_equal(BigDecimal::SIGN_POSITIVE_ZERO, (BigDecimal("0") - 0).sign)
+    assert_equal(BigDecimal::SIGN_NEGATIVE_ZERO, (BigDecimal("-0") - 0).sign)
+    assert_equal(BigDecimal::SIGN_POSITIVE_ZERO, (BigDecimal("-0") - BigDecimal("-0")).sign)
 
-    x = BigDecimal.new((2**100).to_s)
-    assert_equal(BigDecimal.new((2**100-1).to_s), x - 1)
+    x = BigDecimal((2**100).to_s)
+    assert_equal(BigDecimal((2**100-1).to_s), x - 1)
 
     BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)
     inf    = BigDecimal("Infinity")
@@ -755,19 +758,19 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_sub_with_float
-    assert_kind_of(BigDecimal, BigDecimal.new("3") - 1.0)
+    assert_kind_of(BigDecimal, BigDecimal("3") - 1.0)
   end
 
   def test_sub_with_rational
-    assert_kind_of(BigDecimal, BigDecimal.new("3") - 1.quo(3))
+    assert_kind_of(BigDecimal, BigDecimal("3") - 1.quo(3))
   end
 
   def test_mult
-    x = BigDecimal.new((2**100).to_s)
-    assert_equal(BigDecimal.new((2**100 * 3).to_s), (x * 3).to_i)
+    x = BigDecimal((2**100).to_s)
+    assert_equal(BigDecimal((2**100 * 3).to_s), (x * 3).to_i)
     assert_equal(x, (x * 1).to_i)
     assert_equal(x, (BigDecimal("1") * x).to_i)
-    assert_equal(BigDecimal.new((2**200).to_s), (x * x).to_i)
+    assert_equal(BigDecimal((2**200).to_s), (x * x).to_i)
 
     BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)
     inf    = BigDecimal("Infinity")
@@ -779,11 +782,11 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_mult_with_float
-    assert_kind_of(BigDecimal, BigDecimal.new("3") * 1.5)
+    assert_kind_of(BigDecimal, BigDecimal("3") * 1.5)
   end
 
   def test_mult_with_rational
-    assert_kind_of(BigDecimal, BigDecimal.new("3") * 1.quo(3))
+    assert_kind_of(BigDecimal, BigDecimal("3") * 1.quo(3))
   end
 
   def test_mult_with_nil
@@ -793,39 +796,39 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_div
-    x = BigDecimal.new((2**100).to_s)
-    assert_equal(BigDecimal.new((2**100 / 3).to_s), (x / 3).to_i)
-    assert_equal(BigDecimal::SIGN_POSITIVE_ZERO, (BigDecimal.new("0") / 1).sign)
-    assert_equal(BigDecimal::SIGN_NEGATIVE_ZERO, (BigDecimal.new("-0") / 1).sign)
-    assert_equal(2, BigDecimal.new("2") / 1)
-    assert_equal(-2, BigDecimal.new("2") / -1)
+    x = BigDecimal((2**100).to_s)
+    assert_equal(BigDecimal((2**100 / 3).to_s), (x / 3).to_i)
+    assert_equal(BigDecimal::SIGN_POSITIVE_ZERO, (BigDecimal("0") / 1).sign)
+    assert_equal(BigDecimal::SIGN_NEGATIVE_ZERO, (BigDecimal("-0") / 1).sign)
+    assert_equal(2, BigDecimal("2") / 1)
+    assert_equal(-2, BigDecimal("2") / -1)
 
     assert_equal(BigDecimal('1486.868686869'), BigDecimal('1472.0') / BigDecimal('0.99'), '[ruby-core:59365] [#9316]')
 
     assert_equal(4.124045235, BigDecimal('0.9932') / (700 * BigDecimal('0.344045') / BigDecimal('1000.0')), '[#9305]')
 
     BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)
-    assert_positive_zero(BigDecimal.new("1.0")  / BigDecimal.new("Infinity"))
-    assert_negative_zero(BigDecimal.new("-1.0") / BigDecimal.new("Infinity"))
-    assert_negative_zero(BigDecimal.new("1.0")  / BigDecimal.new("-Infinity"))
-    assert_positive_zero(BigDecimal.new("-1.0") / BigDecimal.new("-Infinity"))
+    assert_positive_zero(BigDecimal("1.0")  / BigDecimal("Infinity"))
+    assert_negative_zero(BigDecimal("-1.0") / BigDecimal("Infinity"))
+    assert_negative_zero(BigDecimal("1.0")  / BigDecimal("-Infinity"))
+    assert_positive_zero(BigDecimal("-1.0") / BigDecimal("-Infinity"))
 
     BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, true)
     BigDecimal.mode(BigDecimal::EXCEPTION_ZERODIVIDE, false)
-    assert_raise_with_message(FloatDomainError, "Computation results to 'Infinity'") { BigDecimal.new("1") / 0 }
-    assert_raise_with_message(FloatDomainError, "Computation results to '-Infinity'") { BigDecimal.new("-1") / 0 }
+    assert_raise_with_message(FloatDomainError, "Computation results to 'Infinity'") { BigDecimal("1") / 0 }
+    assert_raise_with_message(FloatDomainError, "Computation results to '-Infinity'") { BigDecimal("-1") / 0 }
   end
 
   def test_div_with_float
-    assert_kind_of(BigDecimal, BigDecimal.new("3") / 1.5)
+    assert_kind_of(BigDecimal, BigDecimal("3") / 1.5)
   end
 
   def test_div_with_rational
-    assert_kind_of(BigDecimal, BigDecimal.new("3") / 1.quo(3))
+    assert_kind_of(BigDecimal, BigDecimal("3") / 1.quo(3))
   end
 
   def test_mod
-    x = BigDecimal.new((2**100).to_s)
+    x = BigDecimal((2**100).to_s)
     assert_equal(1, x % 3)
     assert_equal(2, (-x) % 3)
     assert_equal(-2, x % -3)
@@ -833,15 +836,15 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_mod_with_float
-    assert_kind_of(BigDecimal, BigDecimal.new("3") % 1.5)
+    assert_kind_of(BigDecimal, BigDecimal("3") % 1.5)
   end
 
   def test_mod_with_rational
-    assert_kind_of(BigDecimal, BigDecimal.new("3") % 1.quo(3))
+    assert_kind_of(BigDecimal, BigDecimal("3") % 1.quo(3))
   end
 
   def test_remainder
-    x = BigDecimal.new((2**100).to_s)
+    x = BigDecimal((2**100).to_s)
     assert_equal(1, x.remainder(3))
     assert_equal(-1, (-x).remainder(3))
     assert_equal(1, x.remainder(-3))
@@ -849,47 +852,47 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_remainder_with_float
-    assert_kind_of(BigDecimal, BigDecimal.new("3").remainder(1.5))
+    assert_kind_of(BigDecimal, BigDecimal("3").remainder(1.5))
   end
 
   def test_remainder_with_rational
-    assert_kind_of(BigDecimal, BigDecimal.new("3").remainder(1.quo(3)))
+    assert_kind_of(BigDecimal, BigDecimal("3").remainder(1.quo(3)))
   end
 
   def test_divmod
-    x = BigDecimal.new((2**100).to_s)
+    x = BigDecimal((2**100).to_s)
     assert_equal([(x / 3).floor, 1], x.divmod(3))
     assert_equal([(-x / 3).floor, 2], (-x).divmod(3))
 
-    assert_equal([0, 0], BigDecimal.new("0").divmod(2))
+    assert_equal([0, 0], BigDecimal("0").divmod(2))
 
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-    assert_raise(ZeroDivisionError){BigDecimal.new("0").divmod(0)}
+    assert_raise(ZeroDivisionError){BigDecimal("0").divmod(0)}
   end
 
   def test_add_bigdecimal
-    x = BigDecimal.new((2**100).to_s)
+    x = BigDecimal((2**100).to_s)
     assert_equal(3000000000000000000000000000000, x.add(x, 1))
     assert_equal(2500000000000000000000000000000, x.add(x, 2))
     assert_equal(2540000000000000000000000000000, x.add(x, 3))
   end
 
   def test_sub_bigdecimal
-    x = BigDecimal.new((2**100).to_s)
+    x = BigDecimal((2**100).to_s)
     assert_equal(1000000000000000000000000000000, x.sub(1, 1))
     assert_equal(1300000000000000000000000000000, x.sub(1, 2))
     assert_equal(1270000000000000000000000000000, x.sub(1, 3))
   end
 
   def test_mult_bigdecimal
-    x = BigDecimal.new((2**100).to_s)
+    x = BigDecimal((2**100).to_s)
     assert_equal(4000000000000000000000000000000, x.mult(3, 1))
     assert_equal(3800000000000000000000000000000, x.mult(3, 2))
     assert_equal(3800000000000000000000000000000, x.mult(3, 3))
   end
 
   def test_div_bigdecimal
-    x = BigDecimal.new((2**100).to_s)
+    x = BigDecimal((2**100).to_s)
     assert_equal(422550200076076467165567735125, x.div(3))
     assert_equal(400000000000000000000000000000, x.div(3, 1))
     assert_equal(420000000000000000000000000000, x.div(3, 2))
@@ -901,49 +904,49 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_abs_bigdecimal
-    x = BigDecimal.new((2**100).to_s)
+    x = BigDecimal((2**100).to_s)
     assert_equal(1267650600228229401496703205376, x.abs)
-    x = BigDecimal.new("-" + (2**100).to_s)
+    x = BigDecimal("-" + (2**100).to_s)
     assert_equal(1267650600228229401496703205376, x.abs)
-    x = BigDecimal.new("0")
+    x = BigDecimal("0")
     assert_equal(0, x.abs)
-    x = BigDecimal.new("-0")
+    x = BigDecimal("-0")
     assert_equal(0, x.abs)
 
     BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)
-    x = BigDecimal.new("Infinity")
-    assert_equal(BigDecimal.new("Infinity"), x.abs)
-    x = BigDecimal.new("-Infinity")
-    assert_equal(BigDecimal.new("Infinity"), x.abs)
+    x = BigDecimal("Infinity")
+    assert_equal(BigDecimal("Infinity"), x.abs)
+    x = BigDecimal("-Infinity")
+    assert_equal(BigDecimal("Infinity"), x.abs)
 
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-    x = BigDecimal.new("NaN")
+    x = BigDecimal("NaN")
     assert_nan(x.abs)
   end
 
   def test_sqrt_bigdecimal
-    x = BigDecimal.new("0.09")
+    x = BigDecimal("0.09")
     assert_in_delta(0.3, x.sqrt(1), 0.001)
-    x = BigDecimal.new((2**100).to_s)
+    x = BigDecimal((2**100).to_s)
     y = BigDecimal("1125899906842624")
     e = y.exponent
     assert_equal(true, (x.sqrt(100) - y).abs < BigDecimal("1E#{e-100}"))
     assert_equal(true, (x.sqrt(200) - y).abs < BigDecimal("1E#{e-200}"))
     assert_equal(true, (x.sqrt(300) - y).abs < BigDecimal("1E#{e-300}"))
-    x = BigDecimal.new("-" + (2**100).to_s)
+    x = BigDecimal("-" + (2**100).to_s)
     assert_raise_with_message(FloatDomainError, "sqrt of negative value") { x.sqrt(1) }
-    x = BigDecimal.new((2**200).to_s)
+    x = BigDecimal((2**200).to_s)
     assert_equal(2**100, x.sqrt(1))
 
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-    assert_raise_with_message(FloatDomainError, "sqrt of 'NaN'(Not a Number)") { BigDecimal.new("NaN").sqrt(1) }
-    assert_raise_with_message(FloatDomainError, "sqrt of negative value") { BigDecimal.new("-Infinity").sqrt(1) }
+    assert_raise_with_message(FloatDomainError, "sqrt of 'NaN'(Not a Number)") { BigDecimal("NaN").sqrt(1) }
+    assert_raise_with_message(FloatDomainError, "sqrt of negative value") { BigDecimal("-Infinity").sqrt(1) }
 
-    assert_equal(0, BigDecimal.new("0").sqrt(1))
-    assert_equal(0, BigDecimal.new("-0").sqrt(1))
-    assert_equal(1, BigDecimal.new("1").sqrt(1))
-    assert_positive_infinite(BigDecimal.new("Infinity").sqrt(1))
+    assert_equal(0, BigDecimal("0").sqrt(1))
+    assert_equal(0, BigDecimal("-0").sqrt(1))
+    assert_equal(1, BigDecimal("1").sqrt(1))
+    assert_positive_infinite(BigDecimal("Infinity").sqrt(1))
   end
 
   def test_sqrt_5266
@@ -961,26 +964,26 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_fix
-    x = BigDecimal.new("1.1")
+    x = BigDecimal("1.1")
     assert_equal(1, x.fix)
     assert_kind_of(BigDecimal, x.fix)
   end
 
   def test_frac
-    x = BigDecimal.new("1.1")
+    x = BigDecimal("1.1")
     assert_equal(0.1, x.frac)
-    assert_equal(0.1, BigDecimal.new("0.1").frac)
+    assert_equal(0.1, BigDecimal("0.1").frac)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-    assert_nan(BigDecimal.new("NaN").frac)
+    assert_nan(BigDecimal("NaN").frac)
   end
 
   def test_round
-    assert_equal(3, BigDecimal.new("3.14159").round)
-    assert_equal(9, BigDecimal.new("8.7").round)
-    assert_equal(3.142, BigDecimal.new("3.14159").round(3))
-    assert_equal(13300.0, BigDecimal.new("13345.234").round(-2))
+    assert_equal(3, BigDecimal("3.14159").round)
+    assert_equal(9, BigDecimal("8.7").round)
+    assert_equal(3.142, BigDecimal("3.14159").round(3))
+    assert_equal(13300.0, BigDecimal("13345.234").round(-2))
 
-    x = BigDecimal.new("111.111")
+    x = BigDecimal("111.111")
     assert_equal(111    , x.round)
     assert_equal(111.1  , x.round(1))
     assert_equal(111.11 , x.round(2))
@@ -991,7 +994,7 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(  0    , x.round(-3))
     assert_equal(  0    , x.round(-4))
 
-    x = BigDecimal.new("2.5")
+    x = BigDecimal("2.5")
     assert_equal(3, x.round(0, BigDecimal::ROUND_UP))
     assert_equal(2, x.round(0, BigDecimal::ROUND_DOWN))
     assert_equal(3, x.round(0, BigDecimal::ROUND_HALF_UP))
@@ -1001,7 +1004,7 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(2, x.round(0, BigDecimal::ROUND_FLOOR))
     assert_raise(ArgumentError) { x.round(0, 256) }
 
-    x = BigDecimal.new("-2.5")
+    x = BigDecimal("-2.5")
     assert_equal(-3, x.round(0, BigDecimal::ROUND_UP))
     assert_equal(-2, x.round(0, BigDecimal::ROUND_DOWN))
     assert_equal(-3, x.round(0, BigDecimal::ROUND_HALF_UP))
@@ -1016,13 +1019,13 @@ class TestBigDecimal < Test::Unit::TestCase
 
     bug3803 = '[ruby-core:32136]'
     15.times do |n|
-      x = BigDecimal.new("5#{'0'*n}1")
+      x = BigDecimal("5#{'0'*n}1")
       assert_equal(10**(n+2), x.round(-(n+2), BigDecimal::ROUND_HALF_DOWN), bug3803)
       assert_equal(10**(n+2), x.round(-(n+2), BigDecimal::ROUND_HALF_EVEN), bug3803)
-      x = BigDecimal.new("0.5#{'0'*n}1")
+      x = BigDecimal("0.5#{'0'*n}1")
       assert_equal(1, x.round(0, BigDecimal::ROUND_HALF_DOWN), bug3803)
       assert_equal(1, x.round(0, BigDecimal::ROUND_HALF_EVEN), bug3803)
-      x = BigDecimal.new("-0.5#{'0'*n}1")
+      x = BigDecimal("-0.5#{'0'*n}1")
       assert_equal(-1, x.round(0, BigDecimal::ROUND_HALF_DOWN), bug3803)
       assert_equal(-1, x.round(0, BigDecimal::ROUND_HALF_EVEN), bug3803)
     end
@@ -1092,7 +1095,7 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_round_half_nil
-    x = BigDecimal.new("2.5")
+    x = BigDecimal("2.5")
 
     BigDecimal.save_rounding_mode do
       BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_UP)
@@ -1136,66 +1139,66 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_truncate
-    assert_equal(3, BigDecimal.new("3.14159").truncate)
-    assert_equal(8, BigDecimal.new("8.7").truncate)
-    assert_equal(3.141, BigDecimal.new("3.14159").truncate(3))
-    assert_equal(13300.0, BigDecimal.new("13345.234").truncate(-2))
+    assert_equal(3, BigDecimal("3.14159").truncate)
+    assert_equal(8, BigDecimal("8.7").truncate)
+    assert_equal(3.141, BigDecimal("3.14159").truncate(3))
+    assert_equal(13300.0, BigDecimal("13345.234").truncate(-2))
 
-    assert_equal(-3, BigDecimal.new("-3.14159").truncate)
-    assert_equal(-8, BigDecimal.new("-8.7").truncate)
-    assert_equal(-3.141, BigDecimal.new("-3.14159").truncate(3))
-    assert_equal(-13300.0, BigDecimal.new("-13345.234").truncate(-2))
+    assert_equal(-3, BigDecimal("-3.14159").truncate)
+    assert_equal(-8, BigDecimal("-8.7").truncate)
+    assert_equal(-3.141, BigDecimal("-3.14159").truncate(3))
+    assert_equal(-13300.0, BigDecimal("-13345.234").truncate(-2))
   end
 
   def test_floor
-    assert_equal(3, BigDecimal.new("3.14159").floor)
-    assert_equal(-10, BigDecimal.new("-9.1").floor)
-    assert_equal(3.141, BigDecimal.new("3.14159").floor(3))
-    assert_equal(13300.0, BigDecimal.new("13345.234").floor(-2))
+    assert_equal(3, BigDecimal("3.14159").floor)
+    assert_equal(-10, BigDecimal("-9.1").floor)
+    assert_equal(3.141, BigDecimal("3.14159").floor(3))
+    assert_equal(13300.0, BigDecimal("13345.234").floor(-2))
   end
 
   def test_ceil
-    assert_equal(4, BigDecimal.new("3.14159").ceil)
-    assert_equal(-9, BigDecimal.new("-9.1").ceil)
-    assert_equal(3.142, BigDecimal.new("3.14159").ceil(3))
-    assert_equal(13400.0, BigDecimal.new("13345.234").ceil(-2))
+    assert_equal(4, BigDecimal("3.14159").ceil)
+    assert_equal(-9, BigDecimal("-9.1").ceil)
+    assert_equal(3.142, BigDecimal("3.14159").ceil(3))
+    assert_equal(13400.0, BigDecimal("13345.234").ceil(-2))
   end
 
   def test_to_s
-    assert_equal('-123.45678 90123 45678 9', BigDecimal.new('-123.45678901234567890').to_s('5F'))
-    assert_equal('+123.45678901 23456789', BigDecimal.new('123.45678901234567890').to_s('+8F'))
-    assert_equal(' 123.4567890123456789', BigDecimal.new('123.45678901234567890').to_s(' F'))
-    assert_equal('0.1234567890123456789e3', BigDecimal.new('123.45678901234567890').to_s)
-    assert_equal('0.12345 67890 12345 6789e3', BigDecimal.new('123.45678901234567890').to_s(5))
+    assert_equal('-123.45678 90123 45678 9', BigDecimal('-123.45678901234567890').to_s('5F'))
+    assert_equal('+123.45678901 23456789', BigDecimal('123.45678901234567890').to_s('+8F'))
+    assert_equal(' 123.4567890123456789', BigDecimal('123.45678901234567890').to_s(' F'))
+    assert_equal('0.1234567890123456789e3', BigDecimal('123.45678901234567890').to_s)
+    assert_equal('0.12345 67890 12345 6789e3', BigDecimal('123.45678901234567890').to_s(5))
   end
 
   def test_split
-    x = BigDecimal.new('-123.45678901234567890')
+    x = BigDecimal('-123.45678901234567890')
     assert_equal([-1, "1234567890123456789", 10, 3], x.split)
-    assert_equal([1, "0", 10, 0], BigDecimal.new("0").split)
-    assert_equal([-1, "0", 10, 0], BigDecimal.new("-0").split)
+    assert_equal([1, "0", 10, 0], BigDecimal("0").split)
+    assert_equal([-1, "0", 10, 0], BigDecimal("-0").split)
 
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-    assert_equal([0, "NaN", 10, 0], BigDecimal.new("NaN").split)
-    assert_equal([1, "Infinity", 10, 0], BigDecimal.new("Infinity").split)
-    assert_equal([-1, "Infinity", 10, 0], BigDecimal.new("-Infinity").split)
+    assert_equal([0, "NaN", 10, 0], BigDecimal("NaN").split)
+    assert_equal([1, "Infinity", 10, 0], BigDecimal("Infinity").split)
+    assert_equal([-1, "Infinity", 10, 0], BigDecimal("-Infinity").split)
   end
 
   def test_exponent
-    x = BigDecimal.new('-123.45678901234567890')
+    x = BigDecimal('-123.45678901234567890')
     assert_equal(3, x.exponent)
   end
 
   def test_inspect
-    assert_equal("0.123456789012e0", BigDecimal.new("0.123456789012").inspect)
-    assert_equal("0.123456789012e4", BigDecimal.new("1234.56789012").inspect)
-    assert_equal("0.123456789012e-4", BigDecimal.new("0.0000123456789012").inspect)
+    assert_equal("0.123456789012e0", BigDecimal("0.123456789012").inspect)
+    assert_equal("0.123456789012e4", BigDecimal("1234.56789012").inspect)
+    assert_equal("0.123456789012e-4", BigDecimal("0.0000123456789012").inspect)
   end
 
   def test_power
     assert_nothing_raised(TypeError, '[ruby-core:47632]') do
-      1000.times { BigDecimal.new('1001.10')**0.75 }
+      1000.times { BigDecimal('1001.10')**0.75 }
     end
   end
 
@@ -1394,7 +1397,7 @@ class TestBigDecimal < Test::Unit::TestCase
 
   def test_limit
     BigDecimal.limit(1)
-    x = BigDecimal.new("3")
+    x = BigDecimal("3")
     assert_equal(90, x ** 4) # OK? must it be 80?
     # 3 * 3 * 3 * 3 = 10 * 3 * 3 = 30 * 3 = 90 ???
     assert_raise(ArgumentError) { BigDecimal.limit(-1) }
@@ -1424,19 +1427,19 @@ class TestBigDecimal < Test::Unit::TestCase
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_ZERODIVIDE, false)
 
-    assert_equal(BigDecimal::SIGN_POSITIVE_ZERO, BigDecimal.new("0").sign)
-    assert_equal(BigDecimal::SIGN_NEGATIVE_ZERO, BigDecimal.new("-0").sign)
-    assert_equal(BigDecimal::SIGN_POSITIVE_FINITE, BigDecimal.new("1").sign)
-    assert_equal(BigDecimal::SIGN_NEGATIVE_FINITE, BigDecimal.new("-1").sign)
-    assert_equal(BigDecimal::SIGN_POSITIVE_INFINITE, (BigDecimal.new("1") / 0).sign)
-    assert_equal(BigDecimal::SIGN_NEGATIVE_INFINITE, (BigDecimal.new("-1") / 0).sign)
-    assert_equal(BigDecimal::SIGN_NaN, (BigDecimal.new("0") / 0).sign)
+    assert_equal(BigDecimal::SIGN_POSITIVE_ZERO, BigDecimal("0").sign)
+    assert_equal(BigDecimal::SIGN_NEGATIVE_ZERO, BigDecimal("-0").sign)
+    assert_equal(BigDecimal::SIGN_POSITIVE_FINITE, BigDecimal("1").sign)
+    assert_equal(BigDecimal::SIGN_NEGATIVE_FINITE, BigDecimal("-1").sign)
+    assert_equal(BigDecimal::SIGN_POSITIVE_INFINITE, (BigDecimal("1") / 0).sign)
+    assert_equal(BigDecimal::SIGN_NEGATIVE_INFINITE, (BigDecimal("-1") / 0).sign)
+    assert_equal(BigDecimal::SIGN_NaN, (BigDecimal("0") / 0).sign)
   end
 
   def test_inf
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-    inf = BigDecimal.new("Infinity")
+    inf = BigDecimal("Infinity")
 
     assert_equal(inf, inf + inf)
     assert_nan((inf + (-inf)))
@@ -1463,14 +1466,14 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_to_special_string
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-    nan = BigDecimal.new("NaN")
+    nan = BigDecimal("NaN")
     assert_equal("NaN", nan.to_s)
-    inf = BigDecimal.new("Infinity")
+    inf = BigDecimal("Infinity")
     assert_equal("Infinity", inf.to_s)
     assert_equal(" Infinity", inf.to_s(" "))
     assert_equal("+Infinity", inf.to_s("+"))
     assert_equal("-Infinity", (-inf).to_s)
-    pzero = BigDecimal.new("0")
+    pzero = BigDecimal("0")
     assert_equal("0.0", pzero.to_s)
     assert_equal(" 0.0", pzero.to_s(" "))
     assert_equal("+0.0", pzero.to_s("+"))
@@ -1486,15 +1489,15 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_ctov
-    assert_equal(0.1, BigDecimal.new("1E-1"))
-    assert_equal(10, BigDecimal.new("1E+1"))
-    assert_equal(1, BigDecimal.new("+1"))
+    assert_equal(0.1, BigDecimal("1E-1"))
+    assert_equal(10, BigDecimal("1E+1"))
+    assert_equal(1, BigDecimal("+1"))
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
 
-    assert_equal(BigDecimal::SIGN_POSITIVE_INFINITE, BigDecimal.new("1E1" + "0" * 10000).sign)
-    assert_equal(BigDecimal::SIGN_NEGATIVE_INFINITE, BigDecimal.new("-1E1" + "0" * 10000).sign)
-    assert_equal(BigDecimal::SIGN_POSITIVE_ZERO, BigDecimal.new("1E-1" + "0" * 10000).sign)
-    assert_equal(BigDecimal::SIGN_NEGATIVE_ZERO, BigDecimal.new("-1E-1" + "0" * 10000).sign)
+    assert_equal(BigDecimal::SIGN_POSITIVE_INFINITE, BigDecimal("1E1" + "0" * 10000).sign)
+    assert_equal(BigDecimal::SIGN_NEGATIVE_INFINITE, BigDecimal("-1E1" + "0" * 10000).sign)
+    assert_equal(BigDecimal::SIGN_POSITIVE_ZERO, BigDecimal("1E-1" + "0" * 10000).sign)
+    assert_equal(BigDecimal::SIGN_NEGATIVE_ZERO, BigDecimal("-1E-1" + "0" * 10000).sign)
   end
 
   def test_split_under_gc_stress
@@ -1503,7 +1506,7 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_in_out_err(%w[-rbigdecimal --disable-gems], <<-EOS, expect, [], bug3258)
     GC.stress = true
     10.upto(20) do |i|
-      p BigDecimal.new("1"+"0"*i).split
+      p BigDecimal("1"+"0"*i).split
     end
     EOS
   end
@@ -1511,7 +1514,7 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_coerce_under_gc_stress
     assert_in_out_err(%w[-rbigdecimal --disable-gems], <<-EOS, [], [])
       expect = ":too_long_to_embed_as_string can't be coerced into BigDecimal"
-      b = BigDecimal.new("1")
+      b = BigDecimal("1")
       GC.stress = true
       10.times do
         begin
@@ -1791,7 +1794,7 @@ class TestBigDecimal < Test::Unit::TestCase
 
   def test_to_d
     bug6093 = '[ruby-core:42969]'
-    code = "exit(BigDecimal.new('10.0') == 10.0.to_d)"
+    code = "exit(BigDecimal('10.0') == 10.0.to_d)"
     assert_ruby_status(%w[-rbigdecimal -rbigdecimal/util -rmathn -], code, bug6093)
   end if RUBY_VERSION < '2.5' # mathn was removed from Ruby 2.5
 
@@ -1815,7 +1818,7 @@ class TestBigDecimal < Test::Unit::TestCase
     end
 
     def test_no_memory_leak_initialize
-      assert_no_memory_leak("BigDecimal.new")
+      assert_no_memory_leak("BigDecimal()")
     end
 
     def test_no_memory_leak_global_new

--- a/test/test_bigdecimal.rb
+++ b/test/test_bigdecimal.rb
@@ -133,20 +133,22 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_new
-    assert_equal(1, BigDecimal.new("1"))
-    assert_equal(1, BigDecimal.new("1", 1))
-    assert_equal(1, BigDecimal.new(" 1 "))
-    assert_equal(111, BigDecimal.new("1_1_1_"))
-    assert_equal(10**(-1), BigDecimal.new("1E-1"), '#4825')
+    assert_warning(/BigDecimal.new is deprecated/) do
+      assert_equal(1, BigDecimal.new("1"))
+      assert_equal(1, BigDecimal.new("1", 1))
+      assert_equal(1, BigDecimal.new(" 1 "))
+      assert_equal(111, BigDecimal.new("1_1_1_"))
+      assert_equal(10**(-1), BigDecimal.new("1E-1"), '#4825')
 
-    assert_raise(ArgumentError, /"_1_1_1"/) { BigDecimal.new("_1_1_1") }
+      assert_raise(ArgumentError, /"_1_1_1"/) { BigDecimal.new("_1_1_1") }
 
-    BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
-    BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-    assert_positive_infinite(BigDecimal.new("Infinity"))
-    assert_negative_infinite(BigDecimal.new("-Infinity"))
-    assert_nan(BigDecimal.new("NaN"))
-    assert_positive_infinite(BigDecimal.new("1E1111111111111111111"))
+      BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
+      BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
+      assert_positive_infinite(BigDecimal.new("Infinity"))
+      assert_negative_infinite(BigDecimal.new("-Infinity"))
+      assert_nan(BigDecimal.new("NaN"))
+      assert_positive_infinite(BigDecimal.new("1E1111111111111111111"))
+    end
   end
 
   def test_new_with_integer

--- a/test/test_bigdecimal_util.rb
+++ b/test/test_bigdecimal_util.rb
@@ -50,11 +50,11 @@ class TestBigDecimalUtil < Test::Unit::TestCase
   end
 
   def test_String_to_d
-    assert_equal("2.5".to_d, BigDecimal.new('2.5'))
+    assert_equal("2.5".to_d, BigDecimal('2.5'))
   end
 
   def test_invalid_String_to_d
-    assert_equal("invalid".to_d, BigDecimal.new('0.0'))
+    assert_equal("invalid".to_d, BigDecimal('0.0'))
   end
 
 end


### PR DESCRIPTION
To remove `BigDecimal.new` from Ruby 2.6, this should be deprecated during Ruby 2.5 period.