### PR TITLE
Tweak warning message of `BigDecimal.new`. Make the message to contain the correct constructor method name

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2602,7 +2602,7 @@ static Real *BigDecimal_new(int argc, VALUE *argv);
 static VALUE
 BigDecimal_s_new(int argc, VALUE *argv, VALUE self)
 {
-  rb_warning("BigDecimal.new is deprecated");
+  rb_warning("BigDecimal.new is deprecated; use Kernel.BigDecimal method instead.");
   return rb_call_super(argc, argv);
 }
 


### PR DESCRIPTION

Ref: https://github.com/ruby/bigdecimal/commit/533737338db915b00dc7168c3602e4b462b23503

The warning says "BigDecimal.new is deprecated", but the message does not have the correct constructor method name. So I think users confuse when users see the message.
This change adds the correct method name, that is `Kernel.BigDecimal`.
Like https://github.com/ruby/bigdecimal/blob/a11b449ef6acb43c6b8e93fc57c1228d5163a6eb/ext/bigdecimal/bigdecimal.c#L152

What do you think?