### PR TITLE
Stop warning in dup and clone, and just return self

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2645,15 +2645,7 @@ BigDecimal_initialize_copy(VALUE self, VALUE other)
 static VALUE
 BigDecimal_clone(VALUE self)
 {
-  rb_warning("BigDecimal#clone is deprecated.");
-  return rb_call_super(0, NULL);
-}
-
-static VALUE
-BigDecimal_dup(VALUE self)
-{
-  rb_warning("BigDecimal#dup is deprecated.");
-  return rb_call_super(0, NULL);
+  return self;
 }
 
 static Real *
@@ -3449,7 +3441,7 @@ Init_bigdecimal(void)
     rb_define_method(rb_cBigDecimal, "remainder", BigDecimal_remainder, 1);
     rb_define_method(rb_cBigDecimal, "divmod", BigDecimal_divmod, 1);
     rb_define_method(rb_cBigDecimal, "clone", BigDecimal_clone, 0);
-    rb_define_method(rb_cBigDecimal, "dup", BigDecimal_dup, 0);
+    rb_define_method(rb_cBigDecimal, "dup", BigDecimal_clone, 0);
     rb_define_method(rb_cBigDecimal, "to_f", BigDecimal_to_f, 0);
     rb_define_method(rb_cBigDecimal, "abs", BigDecimal_abs, 0);
     rb_define_method(rb_cBigDecimal, "sqrt", BigDecimal_sqrt, 1);

--- a/test/test_bigdecimal.rb
+++ b/test/test_bigdecimal.rb
@@ -1775,25 +1775,27 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_clone
-    assert_warning(/BigDecimal#clone is deprecated/) do
-      BigDecimal(0).clone
+    assert_warning(/^$/) do
+      x = BigDecimal(0)
+      assert_same(x, x.clone)
     end
   end
 
   def test_dup
-    assert_warning(/BigDecimal#dup is deprecated/) do
+    assert_warning(/^$/) do
       [1, -1, 2**100, -2**100].each do |i|
         x = BigDecimal(i)
-        assert_equal(x, x.dup)
+        assert_same(x, x.dup)
       end
     end
   end
 
   def test_dup_subclass
-    assert_warning(/BigDecimal#dup is deprecated/) do
+    assert_warning(/BigDecimal\.new is deprecated/) do
       c = Class.new(BigDecimal)
       x = c.new(1)
       y = x.dup
+      assert_same(x, y)
       assert_equal(1, y)
       assert_kind_of(c, y)
     end


### PR DESCRIPTION
The commits in #85 was wrong.
This is correct treatment of BigDecimal#dup and #clone.