### PR TITLE
Remove unused `__have_macro__` alias from extconf

### DIFF
--- a/ext/bigdecimal/extconf.rb
+++ b/ext/bigdecimal/extconf.rb
@@ -17,8 +17,6 @@ bigdecimal_version =
 
 $defs << %Q[-DRUBY_BIGDECIMAL_VERSION=\\"#{bigdecimal_version}\\"]
 
-alias __have_macro__ have_macro
-
 have_func("labs", "stdlib.h")
 have_func("llabs", "stdlib.h")
 have_func("finite", "math.h")


### PR DESCRIPTION
Hi, team! 👋 

I simple was exploring the source code and came across this one, it seems like unused.

the code was introduced here: https://github.com/ruby/bigdecimal/commit/02b605375c273dfae8c029588c3588b6ab85cab2#diff-92ed9076bbff06f570247479dabdeaaaR4
and then unused since: https://github.com/ruby/bigdecimal/commit/84da504a972c0c5f4692e1b39b93e98fdbfc9a1b#diff-92ed9076bbff06f570247479dabdeaaa