### PR TITLE
when parsing strings, allow a trailing decimal point

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -4046,7 +4046,7 @@ VP_EXPORT Real *
 VpAlloc(size_t mx, const char *szVal)
 {
     const char *orig_szVal = szVal;
-    size_t i, ni, ipn, ipf, nf, ipe, ne, dot_seen, exp_seen, nalloc;
+    size_t i, ni, ipn, ipf, nf, ipe, ne, exp_seen, nalloc;
     char v, *psz;
     int  sign=1;
     Real *vp = NULL;

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -4141,12 +4141,10 @@ VpAlloc(size_t mx, const char *szVal)
     ipf = 0;
     ipe = 0;
     ne  = 0;
-    dot_seen = 0;
     exp_seen = 0;
     if (v) {
         /* other than digit nor \0 */
         if (szVal[i] == '.') {    /* xxx. */
-            dot_seen = 1;
             ++i;
             ipf = i;
             while ((v = szVal[i]) != 0) {    /* get fraction part. */
@@ -4177,7 +4175,7 @@ VpAlloc(size_t mx, const char *szVal)
                 break;
         }
     }
-    if (((ni == 0 || dot_seen) && nf == 0) || (exp_seen && ne == 0)) {
+    if ((ni == 0 && nf == 0) || (exp_seen && ne == 0)) {
 	VALUE str = rb_str_new2(orig_szVal);
 	rb_raise(rb_eArgError, "invalid value for BigDecimal(): \"%"PRIsVALUE"\"", str);
     }

--- a/test/test_bigdecimal.rb
+++ b/test/test_bigdecimal.rb
@@ -65,7 +65,7 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_global_new_with_invalid_string
     [
       '', '.', 'e1', 'd1', '.e', '.d', '1.e', '1.d', '.1e', '.1d',
-      'invlaid value'
+      'invalid value'
     ].each do |invalid_string|
       assert_raise_with_message(ArgumentError, %Q[invalid value for BigDecimal(): "#{invalid_string}"]) do
         BigDecimal(invalid_string)
@@ -78,6 +78,7 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(BigDecimal("-1"), BigDecimal(-1))
     assert_equal(BigDecimal((2**100).to_s), BigDecimal(2**100))
     assert_equal(BigDecimal((-2**100).to_s), BigDecimal(-2**100))
+    assert_equal(BigDecimal("123."), BigDecimal(123))
   end
 
   def test_global_new_with_rational
@@ -88,7 +89,9 @@ class TestBigDecimal < Test::Unit::TestCase
 
   def test_global_new_with_float
     assert_equal(BigDecimal("0.1235"), BigDecimal(0.1234567, 4))
+    assert_equal(BigDecimal(".1235"), BigDecimal(0.1234567, 4))
     assert_equal(BigDecimal("-0.1235"), BigDecimal(-0.1234567, 4))
+    assert_equal(BigDecimal("-.1235"), BigDecimal(-0.1234567, 4))
     assert_raise_with_message(ArgumentError, "can't omit precision for a Float.") { BigDecimal(4.2) }
     assert_raise(ArgumentError) { BigDecimal(0.1, Float::DIG + 2) }
     assert_nothing_raised { BigDecimal(0.1, Float::DIG + 1) }


### PR DESCRIPTION
This fixes an unnecessary breaking change introduced in commit 3081a627cebdc1fc119425c7a9f009dbb6bec8e8.  Numbers with a trailing decimal point, such as "123." are unambiguous, standard in science and engineering, and we were able to parse them before, so it seems like we should be able to handle them. Strings with almost any other kinds of junk at the end are allowed, such as "123.0." or "123,", so it was surprising to find that this particular form of number was not supported.