### PR TITLE
avoid division by zero

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -3745,25 +3745,19 @@ One(void)
 VP_EXPORT double
 VpGetDoubleNaN(void) /* Returns the value of NaN */
 {
-    static double fNaN = 0.0;
-    if (fNaN == 0.0) fNaN = Zero()/Zero();
-    return fNaN;
+    return nan("");
 }
 
 VP_EXPORT double
 VpGetDoublePosInf(void) /* Returns the value of +Infinity */
 {
-    static double fInf = 0.0;
-    if (fInf == 0.0) fInf = One()/Zero();
-    return fInf;
+    return HUGE_VAL;
 }
 
 VP_EXPORT double
 VpGetDoubleNegInf(void) /* Returns the value of -Infinity */
 {
-    static double fInf = 0.0;
-    if (fInf == 0.0) fInf = -(One()/Zero());
-    return fInf;
+    return -HUGE_VAL;
 }
 
 VP_EXPORT double


### PR DESCRIPTION
Division by zero is an undefined behaviour, even when the denominator is double.  OTOH we have direct ways to generate these exceptional values.  Why not just return what you need?