### PR TITLE
Restore `BigDecimal.new` for very old version of Rails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Restore `BigDecimal.new` just for version 1.4 for very old version of Rails
+
+  **Kenta Murata**
+
 * Support `exception:` keyword in `BigDecimal()`
 
   **Kenta Murata**

--- a/lib/bigdecimal.rb
+++ b/lib/bigdecimal.rb
@@ -5,5 +5,6 @@ rescue LoadError
 end
 
 def BigDecimal.new(*args, **kwargs)
+  warn "BigDecimal.new is deprecated; use BigDecimal() method instead.", uplevel: 1
   BigDecimal(*args, **kwargs)
 end

--- a/lib/bigdecimal.rb
+++ b/lib/bigdecimal.rb
@@ -3,3 +3,7 @@ begin
 rescue LoadError
   require 'bigdecimal.so'
 end
+
+def BigDecimal.new(*args, **kwargs)
+  BigDecimal(*args, **kwargs)
+end

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -217,7 +217,13 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_s_new
-    assert_raise_with_message(NoMethodError, /undefined method `new'/) { BigDecimal.new("1") }
+    # TODO: BigDecimal.new will be removed on 1.5
+    # assert_raise_with_message(NoMethodError, /undefined method `new'/) { BigDecimal.new("1") }
+    assert_equal(BigDecimal(1), BigDecimal.new(1))
+    assert_raise(ArgumentError) { BigDecimal.new(',', exception: true) }
+    assert_nothing_raised { assert_equal(nil, BigDecimal.new(',', exception: false)) }
+    assert_raise(TypeError) { BigDecimal.new(nil, exception: true) }
+    assert_nothing_raised { assert_equal(nil, BigDecimal.new(nil, exception: false)) }
   end
 
   def _test_mode(type)
@@ -1821,7 +1827,13 @@ class TestBigDecimal < Test::Unit::TestCase
 
   def test_dup_subclass
     c = Class.new(BigDecimal)
-    assert_raise_with_message(NoMethodError, /undefined method `new'/) { c.new(1) }
+    # TODO: BigDecimal.new will be removed on 1.5
+    # assert_raise_with_message(NoMethodError, /undefined method `new'/) { c.new(1) }
+    assert_equal(BigDecimal(1), c.new(1))
+    assert_raise(ArgumentError) { c.new(',', exception: true) }
+    assert_nothing_raised { assert_equal(nil, c.new(',', exception: false)) }
+    assert_raise(TypeError) { c.new(nil, exception: true) }
+    assert_nothing_raised { assert_equal(nil, c.new(nil, exception: false)) }
   end
 
   def test_to_d


### PR DESCRIPTION
This restoration is just only for version 1.4.