### PR TITLE
Fix VpAlloc so that '1.2.3'.to_d is 1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Fix VpAlloc so that '1.2.3'.to_d is 1.2
+
+  **Nobuyoshi Nakada**
+
 * Restore `BigDecimal.new` just for version 1.4 for very old version of Rails
 
   **Kenta Murata**

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -4271,7 +4271,7 @@ VpAlloc(size_t mx, const char *szVal, int strict_p, int exc)
             while (ISSPACE(szVal[j])) ++j;
 
             /* Invalid character */
-            if (szVal[j]) {
+            if (szVal[j] && strict_p) {
                 goto invalid_value;
             }
         }

--- a/test/bigdecimal/test_bigdecimal_util.rb
+++ b/test/bigdecimal/test_bigdecimal_util.rb
@@ -74,6 +74,7 @@ class TestBigDecimalUtil < Test::Unit::TestCase
     assert_equal(BigDecimal('0.1'), "0.1_e10".to_d)
     assert_equal(BigDecimal('0.1'), "0.1e_10".to_d)
     assert_equal(BigDecimal('1'), "0.1e1__0".to_d)
+    assert_equal(BigDecimal('1.2'), "1.2.3".to_d)
 
     assert("2.5".to_d.frozen?)
   end


### PR DESCRIPTION
This fixes https://bugs.ruby-lang.org/issues/15426