### PR TITLE
Fix docs for Jacobian

### DIFF
--- a/lib/bigdecimal/jacobian.rb
+++ b/lib/bigdecimal/jacobian.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: false
-#
+
+require 'bigdecimal'
+
 # require 'bigdecimal/jacobian'
 #
 # Provides methods to compute the Jacobian matrix of a set of equations at a
@@ -21,9 +23,6 @@
 #
 # fx is f.values(x).
 #
-
-require 'bigdecimal'
-
 module Jacobian
   module_function
 


### PR DESCRIPTION
Since https://github.com/ruby/bigdecimal/commit/3d1bdee3766b7eb611a2d845012f0eedaa3a790c, `require` is placed the way that makes class docs invisible for RDoc. See: http://ruby-doc.org/stdlib-2.6/libdoc/bigdecimal/rdoc/Jacobian.html vs https://ruby-doc.org/stdlib-2.5.0/libdoc/bigdecimal/rdoc/Jacobian.html

This PR fixes the problem.