### PR TITLE
String#to_d should match String#to_f behavior with trailing decimal or 'e'

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -4281,7 +4281,7 @@ VpAlloc(size_t mx, const char *szVal, int strict_p, int exc)
 
     psz[i] = '\0';
 
-    if (((ni == 0 || dot_seen) && nf == 0) || (exp_seen && ne == 0)) {
+    if (strict_p && (((ni == 0 || dot_seen) && nf == 0) || (exp_seen && ne == 0))) {
         VALUE str;
       invalid_value:
         if (!strict_p) {

--- a/test/bigdecimal/test_bigdecimal_util.rb
+++ b/test/bigdecimal/test_bigdecimal_util.rb
@@ -76,6 +76,7 @@ class TestBigDecimalUtil < Test::Unit::TestCase
     assert_equal(BigDecimal('1'), "0.1e1__0".to_d)
     assert_equal(BigDecimal('1.2'), "1.2.3".to_d)
     assert_equal(BigDecimal('1'), "1.".to_d)
+    assert_equal(BigDecimal('1'), "1e".to_d)
 
     assert("2.5".to_d.frozen?)
   end

--- a/test/bigdecimal/test_bigdecimal_util.rb
+++ b/test/bigdecimal/test_bigdecimal_util.rb
@@ -75,6 +75,7 @@ class TestBigDecimalUtil < Test::Unit::TestCase
     assert_equal(BigDecimal('0.1'), "0.1e_10".to_d)
     assert_equal(BigDecimal('1'), "0.1e1__0".to_d)
     assert_equal(BigDecimal('1.2'), "1.2.3".to_d)
+    assert_equal(BigDecimal('1'), "1.".to_d)
 
     assert("2.5".to_d.frozen?)
   end


### PR DESCRIPTION
In `String#to_d`, it should be more forgiving for missing fractional or exponential parts, just like `String#to_f`. This adds specs and updates the behavior so that this is the case.

```ruby
$ irb
irb(main):001:0> require 'bigdecimal/util'
=> true
irb(main):002:0> '1.'.to_f
=> 1.0
irb(main):003:0> '1e'.to_f
=> 1.0
irb(main):004:0> '1.'.to_d
=> 0.0
irb(main):005:0> '1e'.to_d
=> 0.0
```
See #131 and #63 (in particular, https://github.com/ruby/bigdecimal/issues/63#issuecomment-297544464 mentions this issue). The fix in #87 did not fix this case.