### PR TITLE
Update docs on `BigDecimal#round`

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -1756,11 +1756,15 @@ BigDecimal_fix(VALUE self)
  * round(n, mode)
  *
  * Round to the nearest integer (by default), returning the result as a
- * BigDecimal.
+ * BigDecimal if n is specified, or as Integer if it isn't.
+ *
  *
  *	BigDecimal('3.14159').round #=> 3
  *	BigDecimal('8.7').round #=> 9
  *	BigDecimal('-9.9').round #=> -10
+ *
+ *	BigDecimal('3.14159').round(2).class.name #=> "BigDecimal"
+ *	BigDecimal('3.14159').round.class.name #=> "Integer"
  *
  * If n is specified and positive, the fractional part of the result has no
  * more than that many digits.

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -1756,7 +1756,7 @@ BigDecimal_fix(VALUE self)
  * round(n, mode)
  *
  * Round to the nearest integer (by default), returning the result as a
- * BigDecimal if n is specified, or as Integer if it isn't.
+ * BigDecimal if n is specified, or as an Integer if it isn't.
  *
  *	BigDecimal('3.14159').round #=> 3
  *	BigDecimal('8.7').round #=> 9

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -1758,7 +1758,6 @@ BigDecimal_fix(VALUE self)
  * Round to the nearest integer (by default), returning the result as a
  * BigDecimal if n is specified, or as Integer if it isn't.
  *
- *
  *	BigDecimal('3.14159').round #=> 3
  *	BigDecimal('8.7').round #=> 9
  *	BigDecimal('-9.9').round #=> -10


### PR DESCRIPTION
When calling `BigDecimal#round` without any argument, it casts the result to an `Integer`, while calling it with an argument (`BigDecimal#round(n)`) keeps the result as a `BigDecimal`.

I think this is an unexpected behavior, but changing it might not be backwards-compatible, so let's document it at the docs at least.

This is a port of https://github.com/ruby/ruby/pull/2149 (in case the correct place to file the PR is here instead of there).