### PR TITLE
Speed up loading bigdecimal gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require "rake/extensiontask"
 require "rake/testtask"
 
 spec = eval(File.read('bigdecimal.gemspec'))
+spec.require_paths.insert(0, *%w[stub])
 Rake::ExtensionTask.new('bigdecimal', spec) do |ext|
   ext.lib_dir = File.join(*['lib', ENV['FAT_DIR']].compact)
   ext.cross_compile = true

--- a/bigdecimal.gemspec
+++ b/bigdecimal.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
     bigdecimal.gemspec
     ext/bigdecimal/bigdecimal.c
     ext/bigdecimal/bigdecimal.h
-    lib/bigdecimal.rb
     lib/bigdecimal/jacobian.rb
     lib/bigdecimal/ludcmp.rb
     lib/bigdecimal/math.rb
@@ -28,6 +27,7 @@ Gem::Specification.new do |s|
     sample/linear.rb
     sample/nlsolve.rb
     sample/pi.rb
+    stub/bigdecimal.rb
   ]
 
   s.required_ruby_version = Gem::Requirement.new(">= 2.3.0".freeze)

--- a/lib/bigdecimal.rb
+++ b/lib/bigdecimal.rb
@@ -1,5 +1,0 @@
-begin
-  require "#{RUBY_VERSION[/\d+\.\d+/]}/bigdecimal.so"
-rescue LoadError
-  require 'bigdecimal.so'
-end

--- a/stub/bigdecimal.rb
+++ b/stub/bigdecimal.rb
@@ -1,0 +1,1 @@
+require "#{RUBY_VERSION[/\d+\.\d+/]}/bigdecimal.so"


### PR DESCRIPTION
This patch drastically reduces time taken to load the gem in all non-Windows platforms.

Here's a quick benchmark result of requiring the gem before and after this patch on my Mac.

```
ruby -e "now = Time.now; gem 'bigdecimal', '1.4.4'; require 'bigdecimal'; p '1.4.4' => Time.now - now"
ruby -e "now = Time.now; gem 'bigdecimal', '2.0.0.dev'; require 'bigdecimal'; p '2.0.0.dev' => Time.now - now"
{"1.4.4"=>0.172034}
{"2.0.0.dev"=>0.003902}
```

This patch was originally written by @nobu for io-console gem, and I'm just copying the solution to this repo, so please read other repos' PRs for more details.
https://github.com/ruby/psych/pull/406
https://github.com/ruby/io-console/pull/4
