### PR TITLE
Do not mutate frozen BigDecimal argument in BigMath.exp

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2956,6 +2956,10 @@ BigMath_s_exp(VALUE klass, VALUE x, VALUE vprec)
     n = prec + rmpd_double_figures();
     negative = BIGDECIMAL_NEGATIVE_P(vx);
     if (negative) {
+        VALUE x_zero = INT2NUM(1);
+        VALUE x_copy = f_BigDecimal(1, &x_zero, klass);
+        x = BigDecimal_initialize_copy(x_copy, x);
+        vx = DATA_PTR(x);
 	VpSetSign(vx, 1);
     }
 

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1606,6 +1606,13 @@ class TestBigDecimal < Test::Unit::TestCase
     end
   end
 
+  def test_exp_with_negative
+    x = BigDecimal(-1)
+    y = BigMath.exp(x, 20)
+    assert_equal(y, BigMath.exp(-1, 20))
+    assert_equal(BigDecimal(-1), x)
+  end
+
   def test_exp_with_negative_infinite
     BigDecimal.save_exception_mode do
       BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)


### PR DESCRIPTION
BigMath.exp would previously mutate a BigDecimal argument if the
argument was negative.  This makes a internal copy of the argument
to avoid the mutation.

Fixes Ruby Bug 8542