### PR TITLE
Update documentation for Kernel#BigDecimal() digits argument [ci skip]

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2681,9 +2681,8 @@ VpNewVarArg(int argc, VALUE *argv)
  *           If it is a String, spaces are ignored and unrecognized characters
  *           terminate the value.
  *
- * digits:: The number of significant digits, as an Integer. If omitted or 0,
- *          the number of significant digits is determined from the initial
- *          value.
+ * digits:: The number of significant digits, as an Integer. This is required if
+ *          +initial+ is a Float or Rational, and ignored otherwise.
  *
  *          The actual number of significant digits used in computation is
  *          usually larger than the specified number.


### PR DESCRIPTION
I expected this to affect the significant digits if providing
the first argument as a String, but it does not.  I'm positive this
argument is ignored if the first argument is an Integer, but I'm
not positive that it is ignored if the first argument is a String,
as the value is passed to VpAlloc. However, if it has an effect,
I'm not sure what it is.