### PR TITLE
Undef BigDecimal#initialize_copy

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -3453,7 +3453,9 @@ Init_bigdecimal(void)
 
 
     /* instance methods */
-    rb_define_method(rb_cBigDecimal, "initialize_copy", BigDecimal_initialize_copy, 1);
+    rb_undef_method(rb_cBigDecimal, "initialize_copy");
+    rb_undef_method(rb_cBigDecimal, "initialize_clone");
+    rb_undef_method(rb_cBigDecimal, "initialize_dup");
     rb_define_method(rb_cBigDecimal, "precs", BigDecimal_prec, 0);
 
     rb_define_method(rb_cBigDecimal, "add", BigDecimal_add2, 2);

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1874,6 +1874,12 @@ class TestBigDecimal < Test::Unit::TestCase
     EOS
   end
 
+  def test_no_initialize_copy
+    assert_equal(false, BigDecimal(1).respond_to?(:initialize_copy, true))
+    assert_equal(false, BigDecimal(1).respond_to?(:initialize_dup, true))
+    assert_equal(false, BigDecimal(1).respond_to?(:initialize_clone, true))
+  end
+
   def assert_no_memory_leak(code, *rest, **opt)
     code = "8.times {20_000.times {begin #{code}; rescue NoMemoryError; end}; GC.start}"
     super(["-rbigdecimal"],


### PR DESCRIPTION
Both BigDecimal#clone and BigDecimal#dup return self, there is no
reason to have initialize_copy exposed as a Ruby method.

The same is true for initialize_clone and initialize_dup.

Fixes #147 