### PR TITLE
Drop Ruby 2.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ script:
 
 matrix:
   include:
-    - name: "2.3"
-      rvm: 2.3
     - name: "2.4"
       rvm: 2.4.5
     - name: "2.5"
@@ -24,5 +22,3 @@ matrix:
       rvm: 2.6
     - name: "trunk"
       rvm: ruby-head
-  allow_failures:
-    - rvm: 2.3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,3 @@ environment:
     - ruby_version: "25-x64"
     - ruby_version: "24"
     - ruby_version: "24-x64"
-matrix:
-  allow_failures:
-    - ruby_version: "23"
-    - ruby_version: "23-x64"

--- a/bigdecimal.gemspec
+++ b/bigdecimal.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     sample/pi.rb
   ]
 
-  s.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  s.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "rake-compiler", ">= 0.9"


### PR DESCRIPTION
I'd like to drop Ruby 2.3 because it has been dead.