### PR TITLE
Remove definition of BigDecimal#initialize_copy

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -3490,9 +3490,6 @@ Init_bigdecimal(void)
 
 
     /* instance methods */
-    rb_undef_method(rb_cBigDecimal, "initialize_copy");
-    rb_undef_method(rb_cBigDecimal, "initialize_clone");
-    rb_undef_method(rb_cBigDecimal, "initialize_dup");
     rb_define_method(rb_cBigDecimal, "precs", BigDecimal_prec, 0);
 
     rb_define_method(rb_cBigDecimal, "add", BigDecimal_add2, 2);

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1882,10 +1882,12 @@ class TestBigDecimal < Test::Unit::TestCase
     EOS
   end
 
-  def test_no_initialize_copy
-    assert_equal(false, BigDecimal(1).respond_to?(:initialize_copy, true))
-    assert_equal(false, BigDecimal(1).respond_to?(:initialize_dup, true))
-    assert_equal(false, BigDecimal(1).respond_to?(:initialize_clone, true))
+  def test_initialize_copy_dup_clone_frozen_error
+    bd = BigDecimal(1)
+    bd2 = BigDecimal(2)
+    assert_raise(FrozenError) { bd.send(:initialize_copy, bd2) }
+    assert_raise(FrozenError) { bd.send(:initialize_clone, bd2) }
+    assert_raise(FrozenError) { bd.send(:initialize_dup, bd2) }
   end
 
   def assert_no_memory_leak(code, *rest, **opt)


### PR DESCRIPTION
This leaves the default definition, which will raise FrozenError.

@eregon prefers this approach.  It's more similar to core classes, and results in fewer method entries.