### PR TITLE
Remove taint checking

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -300,7 +300,6 @@ again:
 #ifdef ENABLE_NUMERIC_STRING
       case T_STRING:
 	StringValueCStr(v);
-	rb_check_safe_obj(v);
 	return VpCreateRbObject(RSTRING_LEN(v) + VpBaseFig() + 1,
 				RSTRING_PTR(v));
 #endif /* ENABLE_NUMERIC_STRING */
@@ -442,7 +441,6 @@ BigDecimal_load(VALUE self, VALUE str)
     unsigned long m=0;
 
     pch = (unsigned char *)StringValueCStr(str);
-    rb_check_safe_obj(str);
     /* First get max prec */
     while((*pch) != (unsigned char)'\0' && (ch = *pch++) != (unsigned char)':') {
         if(!ISDIGIT(ch)) {
@@ -2054,7 +2052,6 @@ BigDecimal_to_s(int argc, VALUE *argv, VALUE self)
     if (rb_scan_args(argc, argv, "01", &f) == 1) {
 	if (RB_TYPE_P(f, T_STRING)) {
 	    psz = StringValueCStr(f);
-	    rb_check_safe_obj(f);
 	    if (*psz == ' ') {
 		fPlus = 1;
 		psz++;

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -158,15 +158,6 @@ class TestBigDecimal < Test::Unit::TestCase
     end
   end
 
-  def test_BigDecimal_with_tainted_string
-    Thread.new {
-      $SAFE = 1
-      BigDecimal('1'.taint)
-    }.join
-  ensure
-    $SAFE = 0
-  end
-
   def test_BigDecimal_with_exception_keyword
     assert_raise(ArgumentError) {
       BigDecimal('.', exception: true)


### PR DESCRIPTION
This removes the taint checking.  Taint support is deprecated in
Ruby 2.7 and has no effect.  I don't think removing the taint
checks in earlier ruby versions will cause any problems.