### PR TITLE
gemspec: Do not distribute the gemspec as a "file"

### DIFF
--- a/bigdecimal.gemspec
+++ b/bigdecimal.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
   s.extensions    = %w[ext/bigdecimal/extconf.rb]
   s.files         = %w[
-    bigdecimal.gemspec
     ext/bigdecimal/bigdecimal.c
     ext/bigdecimal/bigdecimal.h
     ext/bigdecimal/bits.h


### PR DESCRIPTION
This PR removes 1 file from the list of distributed files.

Question: I guess this gem is standard-included with Ruby, so LICENSE.txt is probably not necessary to add. Nor README.md. Do you agree?