### PR TITLE
Silence GCC 11 warnings

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -62,7 +62,7 @@ static ID id_eq;
 static ID id_half;
 
 /* MACRO's to guard objects from GC by keeping them in stack */
-#define ENTER(n) volatile VALUE RB_UNUSED_VAR(vStack[n]);int iStack=0
+#define ENTER(n) RB_UNUSED_VAR() volatile VALUE vStack[n];int iStack=0
 #define PUSH(x)  (vStack[iStack++] = (VALUE)(x))
 #define SAVE(p)  PUSH((p)->obj)
 #define GUARD_OBJ(p,y) ((p)=(y), SAVE(p))


### PR DESCRIPTION
```
../../../ext/bigdecimal/bigdecimal.c: In function 'BigDecimal_prec':
../../../ext/bigdecimal/bigdecimal.c:303:5: warning: 'maybe_unused' attribute ignored [-Wattributes]
  303 |     ENTER(1);
      |     ^~~~~
In file included from ../../../include/ruby/defines.h:73,
                 from ../../../include/ruby/ruby.h:23,
                 from ../../../ext/bigdecimal/bigdecimal.h:13,
                 from ../../../ext/bigdecimal/bigdecimal.c:13:
../../../ext/bigdecimal/bigdecimal.c:65:47: warning: variable 'vStack' set but not used [-Wunused-but-set-variable]
   65 | #define ENTER(n) volatile VALUE RB_UNUSED_VAR(vStack[n]);int iStack=0
      |                                               ^~~~~~
../../../include/ruby/backward/2/attributes.h:168:26: note: in definition of macro 'RB_UNUSED_VAR'
  168 | #define RB_UNUSED_VAR(x) x RBIMPL_ATTR_MAYBE_UNUSED()
      |                          ^
../../../ext/bigdecimal/bigdecimal.c:303:5: note: in expansion of macro 'ENTER'
  303 |     ENTER(1);
      |     ^~~~~
```