### PR TITLE
Include Ruby 2.7 in versions table

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The differences among versions are given below:
 | ------- | --------------- | ----------------------- |
 | 3.0.0   | You can use BigDecimal with Ractor on Ruby 3.0 | 2.5 .. |
 | 2.0.x   | You cannot use BigDecimal.new and do subclassing | 2.4 .. |
-| 1.4.x   | BigDecimal.new and subclassing always prints warning. | 2.3 .. 2.6 |
+| 1.4.x   | BigDecimal.new and subclassing always prints warning. | 2.3 .. 2.7 |
 | 1.3.5   | You can use BigDecimal.new and subclassing without warning | .. 2.5 |
 
 You can select the version you want to use using `gem` method in Gemfile or scripts.


### PR DESCRIPTION
When [this table was first written](https://github.com/ruby/bigdecimal/commit/8b76f25a86abef6d21284aba2db6c2ad4759f90c) (2019-01-10), Ruby 2.7 wasn't released yet (2019-12-25).

I was just looking at it to reference which versions work, and I was worried Ruby 2.7 might not work, but it seems to work the same as 2.6. (I confirmed there's a subclass warning still too, though of course there is).

