### PR TITLE
Fix negative Bignum conversion

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2770,8 +2770,12 @@ rb_big_convert_to_BigDecimal(VALUE val, RB_UNUSED_VAR(size_t digs), int raise_ex
 {
     assert(RB_TYPE_P(val, T_BIGNUM));
 
-    size_t size = rb_absint_size(val, NULL);
+    int leading_zeros;
+    size_t size = rb_absint_size(val, &leading_zeros);
     int sign = FIX2INT(rb_big_cmp(val, INT2FIX(0)));
+    if (sign < 0 && leading_zeros == 0) {
+        size += 1;
+    }
     if (size <= sizeof(long)) {
         if (sign < 0) {
             return rb_int64_convert_to_BigDecimal(NUM2LONG(val), digs, raise_exception);

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -12,7 +12,12 @@ class TestBigDecimal < Test::Unit::TestCase
     require 'fiddle'
     LONG_MAX = (1 << (Fiddle::SIZEOF_LONG*8 - 1)) - 1
     LONG_MIN = [LONG_MAX + 1].pack("L!").unpack("l!")[0]
+    LLONG_MAX = (1 << (Fiddle::SIZEOF_LONG_LONG*8 - 1)) - 1
+    LLONG_MIN = [LLONG_MAX + 1].pack("Q!").unpack("q!")[0]
+    ULLONG_MAX = (1 << Fiddle::SIZEOF_LONG_LONG*8) - 1
     LIMITS = {
+      "LLONG_MIN" => LLONG_MIN,
+      "ULLONG_MAX" => ULLONG_MAX,
       "FIXNUM_MIN" => LONG_MIN / 2,
       "FIXNUM_MAX" => LONG_MAX / 2,
       "INT64_MIN"  => -9223372036854775808,
@@ -2092,10 +2097,9 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_llong_min_gh_200
     # https://github.com/ruby/bigdecimal/issues/199
     # Between LLONG_MIN and -ULLONG_MAX
-    llong_min = -(2 ** 63 + 1)
-    assert_equal(BigDecimal(llong_min.to_s), BigDecimal(llong_min), "[GH-200]")
+    assert_equal(BigDecimal(LIMITS["LLONG_MIN"].to_s), BigDecimal(LIMITS["LLONG_MIN"]), "[GH-200]")
 
-    minus_ullong_max = -(2 ** 64 - 1)
+    minus_ullong_max = -LIMITS["ULLONG_MAX"]
     assert_equal(BigDecimal(minus_ullong_max.to_s), BigDecimal(minus_ullong_max), "[GH-200]")
   end
 

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -2089,6 +2089,16 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_raise(err) { bd.send(:initialize_dup, bd2) }
   end
 
+  def test_llong_min
+    # https://github.com/ruby/bigdecimal/issues/199
+    # Between LLONG_MIN and -ULLONG_MAX
+    llong_min = -(2 ** 63 + 1)
+    assert_equal BigDecimal(llong_min.to_s), BigDecimal(llong_min)
+
+    minus_ullong_max = -(2 ** 64 - 1)
+    assert_equal BigDecimal(minus_ullong_max.to_s), BigDecimal(minus_ullong_max)
+  end
+
   def assert_no_memory_leak(code, *rest, **opt)
     code = "8.times {20_000.times {begin #{code}; rescue NoMemoryError; end}; GC.start}"
     super(["-rbigdecimal"],

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -2089,14 +2089,14 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_raise(err) { bd.send(:initialize_dup, bd2) }
   end
 
-  def test_llong_min
+  def test_llong_min_gh_200
     # https://github.com/ruby/bigdecimal/issues/199
     # Between LLONG_MIN and -ULLONG_MAX
     llong_min = -(2 ** 63 + 1)
-    assert_equal BigDecimal(llong_min.to_s), BigDecimal(llong_min)
+    assert_equal(BigDecimal(llong_min.to_s), BigDecimal(llong_min), "[GH-200]")
 
     minus_ullong_max = -(2 ** 64 - 1)
-    assert_equal BigDecimal(minus_ullong_max.to_s), BigDecimal(minus_ullong_max)
+    assert_equal(BigDecimal(minus_ullong_max.to_s), BigDecimal(minus_ullong_max), "[GH-200]")
   end
 
   def assert_no_memory_leak(code, *rest, **opt)


### PR DESCRIPTION
Fix: https://github.com/ruby/bigdecimal/issues/199

Introduced in 4792a917d806ca1059c952f489413073ea51bf01

`rb_absint_size` return the number of bytes needed to fit the absolute integer, but negative integers need the sign, so one more bit, and potentially one more byte.

I would have expected the same bug to happen between `LONG_MIN` and `-ULONG_MAX` but somehow I couldn't reproduce it.