### PR TITLE
CI: Quote 3.0 to avoid YAML Float-to-String issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         - macos-10.15
         - windows-latest
         ruby:
-        - 3.0
+        - "3.0" # Quoted to avoid 3.0 becoming "3" as a String.
         - 2.7
         - 2.6
         - 2.5


### PR DESCRIPTION
This helps the output of the "name" of the CI Job in the PR checks list not to say "3" when it meant "3.0".

This is a very small change, but which avoids a Float-to-String loss of characters.

An example (not from this project) of what it can look like before this change, in this picture:

<img width="376" alt="bild" src="https://user-images.githubusercontent.com/211/119782378-6ad6cd00-becc-11eb-9e13-9a425adaa054.png">

Read more details, if you like: https://github.com/actions/runner/issues/849