### PR TITLE
Enhanced RDoc for selected methods

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -1096,12 +1096,14 @@ BigDecimal_coerce(VALUE self, VALUE other)
 }
 
 /*
- * call-seq:
- *    +big_decimal  ->  big_decimal
+ *  call-seq:
+ *    +big_decimal -> big_decimal
  *
- * Return self.
+ *  Returns +self+:
  *
- *     +BigDecimal('5')  #=> 0.5e1
+ *     +BigDecimal(5)  # => 0.5e1
+ *     +BigDecimal(-5) # => -0.5e1
+ *
  */
 
 static VALUE
@@ -1111,22 +1113,16 @@ BigDecimal_uplus(VALUE self)
 }
 
  /*
-  * Document-method: BigDecimal#add
-  * Document-method: BigDecimal#+
+  *  call-seq:
+  *    self + value -> new_bigdecimal
   *
-  * call-seq:
-  * add(value, digits)
+  *  Returns the sum of +self+ and +value+:
   *
-  * Add the specified value.
+  *    b = BigDecimal('111111.111') # => 0.111111111e6
+  *    b + 1                        # => 0.111112111e6
   *
-  * e.g.
-  *   c = a.add(b,n)
-  *   c = a + b
-  *
-  * digits:: If specified and less than the number of significant digits of the
-  *          result, the result is rounded to that number of digits, according
-  *          to BigDecimal.mode.
   */
+
 static VALUE
 BigDecimal_add(VALUE self, VALUE r)
 {
@@ -1848,6 +1844,31 @@ BigDecimal_div3(int argc, VALUE *argv, VALUE self)
 
     return BigDecimal_div2(self, b, n);
 }
+
+ /*
+  *  call-seq:
+  *    add(value, ndigits)
+  *
+  *  Returns the sum of +self+ and +value+
+  *  with a precision of +ndigits+ decimal digits.
+  *
+  *  When +ndigits+ is less than the number of significant digits
+  *  in the sum, the sum is rounded to that number of digits,
+  *  according to the current rounding mode; see BigDecimal.mode.
+  *
+  *  Examples:
+  *
+  *    BigDecimal('111111.111').add(1, 0) # => 0.111112111e6
+  *    BigDecimal('111111.111').add(1, 2) # => 0.11e6
+  *    BigDecimal('111111.111').add(1, 3) # => 0.111e6
+  *    BigDecimal('111111.111').add(1, 4) # => 0.1111e6
+  *    BigDecimal('111111.111').add(1, 5) # => 0.11111e6
+  *    BigDecimal('111111.111').add(1, 6) # => 0.111112e6
+  *    BigDecimal('111111.111').add(1, 7) # => 0.1111121e6
+  *    BigDecimal('111111.111').add(1, 8) # => 0.11111211e6
+  *    BigDecimal('111111.111').add(1, 9) # => 0.111112111e6
+  *
+  */
 
 static VALUE
 BigDecimal_add2(VALUE self, VALUE b, VALUE n)

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -1858,6 +1858,8 @@ BigDecimal_div3(int argc, VALUE *argv, VALUE self)
   *
   *  Examples:
   *
+  *    # Set the rounding mode.
+  *    BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_HALF_UP)
   *    BigDecimal('111111.111').add(1, 0) # => 0.111112111e6
   *    BigDecimal('111111.111').add(1, 2) # => 0.11e6
   *    BigDecimal('111111.111').add(1, 3) # => 0.111e6

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -1097,7 +1097,7 @@ BigDecimal_coerce(VALUE self, VALUE other)
 
 /*
  *  call-seq:
- *    +big_decimal -> big_decimal
+ *    +big_decimal -> self
  *
  *  Returns +self+:
  *
@@ -1847,7 +1847,7 @@ BigDecimal_div3(int argc, VALUE *argv, VALUE self)
 
  /*
   *  call-seq:
-  *    add(value, ndigits)
+  *    add(value, ndigits) -> new_bigdecimal
   *
   *  Returns the sum of +self+ and +value+
   *  with a precision of +ndigits+ decimal digits.

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -1859,7 +1859,7 @@ BigDecimal_div3(int argc, VALUE *argv, VALUE self)
   *  Examples:
   *
   *    # Set the rounding mode.
-  *    BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_HALF_UP)
+  *    BigDecimal.mode(BigDecimal::ROUND_MODE, :half_up)
   *    BigDecimal('111111.111').add(1, 0) # => 0.111112111e6
   *    BigDecimal('111111.111').add(1, 2) # => 0.11e6
   *    BigDecimal('111111.111').add(1, 3) # => 0.111e6


### PR DESCRIPTION
Treated:
- #+@
- #add
- #+

A couple of things I've made consistent with usage over at ruby/ruby:

- The second argument to `add`, I've called `ndigits`.
- I've placed the RDoc for the methods immediately before the code, so that `Document-method` is not needed.

I also discovered that `+` and `add` are different, and have documented them separately.
