### PR TITLE
Improve extconf to allow using bigdecimal as a git gem

### DIFF
--- a/bigdecimal.gemspec
+++ b/bigdecimal.gemspec
@@ -1,10 +1,8 @@
 # coding: utf-8
 
-bigdecimal_version = '3.1.0.dev'
-
 Gem::Specification.new do |s|
   s.name          = "bigdecimal"
-  s.version       = bigdecimal_version
+  s.version       = "3.1.0.dev"
   s.authors       = ["Kenta Murata", "Zachary Scott", "Shigeo Kobayashi"]
   s.email         = ["mrkn@mrkn.jp"]
 

--- a/ext/bigdecimal/extconf.rb
+++ b/ext/bigdecimal/extconf.rb
@@ -3,10 +3,7 @@ require 'mkmf'
 
 def check_bigdecimal_version(gemspec_path)
   message "checking RUBY_BIGDECIMAL_VERSION... "
-
-  bigdecimal_version =
-    IO.readlines(gemspec_path)
-      .grep(/\Abigdecimal_version\s+=\s+/)[0][/\'([^\']+)\'/, 1]
+  bigdecimal_version = File.read(gemspec_path).match(/^\s*s\.version\s+=\s+['"]([^'"]+)['"]\s*$/)[1]
 
   version_components = bigdecimal_version.split('.')
   bigdecimal_version = version_components[0, 3].join('.')


### PR DESCRIPTION
e.g.
```
gem "bigdecimal", github: "ruby/bigdecimal"
```

It would fail because bundler regenerates the `gemspec`, so `bigdecimal_version` is gone.

@mrkn 