### PR TITLE
Document precision=0 and ndigits=0 for converting from Float

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -3500,6 +3500,9 @@ rb_convert_to_BigDecimal(VALUE val, size_t digs, int raise_exception)
  *  in the value, the result is rounded to that number of digits,
  *  according to the current rounding mode; see BigDecimal.mode.
  *
+ *  When +ndigits+ is 0, the number of digits to correctly represent a float number
+ *  is determined automatically.
+ *
  *  Returns +value+ converted to a \BigDecimal, depending on the type of +value+:
  *
  *  - Integer, Float, Rational, Complex, or BigDecimal: converted directly:

--- a/lib/bigdecimal/util.rb
+++ b/lib/bigdecimal/util.rb
@@ -33,12 +33,16 @@ class Float < Numeric
   #
   # Returns the value of +float+ as a BigDecimal.
   # The +precision+ parameter is used to determine the number of
-  # significant digits for the result (the default is Float::DIG).
+  # significant digits for the result. When +precision+ is set to +0+,
+  # the number of digits to represent the float being converted is determined
+  # automatically.
+  # The default +precision+ is +0+.
   #
   #     require 'bigdecimal'
   #     require 'bigdecimal/util'
   #
   #     0.5.to_d         # => 0.5e0
+  #     1.234.to_d       # => 0.1234e1
   #     1.234.to_d(2)    # => 0.12e1
   #
   # See also BigDecimal::new.


### PR DESCRIPTION
1. The documentation of `Float#to_d` still mentions the old default value of `precision` (`Float::DIG`). I've updated it and described what does the `precision=0` mean.
2. The description of `ndigits=0` disappeared from the documentation of `BigDecimal` function. I've added a short mention there too. 