### PR TITLE
Handle correctly #reminder with infinity. Fixes #187

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2082,6 +2082,13 @@ BigDecimal_divremain(VALUE self, VALUE r, Real **dv, Real **rv)
     if (!b) return DoSomeOne(self, r, rb_intern("remainder"));
     SAVE(b);
 
+    if (VpIsPosInf(b) || VpIsNegInf(b)) {
+       GUARD_OBJ(*dv, NewZeroWrapLimited(1, 1));
+       VpSetZero(*dv, 1);
+       *rv = a;
+       return Qnil;
+    }
+
     mx = (a->MaxPrec + b->MaxPrec) *VpBaseFig();
     GUARD_OBJ(c,   NewZeroWrapLimited(1, mx));
     GUARD_OBJ(res, NewZeroWrapNolimit(1, (mx+1) * 2 + (VpBaseFig() + 1)));

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -2256,6 +2256,17 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(BigDecimal(minus_ullong_max.to_s), BigDecimal(minus_ullong_max), "[GH-200]")
   end
 
+  def test_reminder_infinity_gh_187
+    # https://github.com/ruby/bigdecimal/issues/187
+    BigDecimal.save_exception_mode do
+      BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)
+      BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
+      bd = BigDecimal("4.2")
+      assert_equal(bd.remainder(BigDecimal("+Infinity")), bd)
+      assert_equal(bd.remainder(BigDecimal("-Infinity")), bd)
+    end
+  end
+
   def assert_no_memory_leak(code, *rest, **opt)
     code = "8.times {20_000.times {begin #{code}; rescue NoMemoryError; end}; GC.start}"
     super(["-rbigdecimal"],


### PR DESCRIPTION
Fixes https://github.com/ruby/bigdecimal/issues/187 by adding a guard to `BigDecimal_divremain`. This returns early if the divider is infinity.
