### PR TITLE
Stub out extension build on JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem "benchmark_driver"
-gem "fiddle"
+gem "fiddle", platform: :ruby
 gem "rake", ">= 12.3.3"
 gem "rake-compiler", ">= 0.9"
 gem "minitest", "< 5.0.0"

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,12 @@ require "rake/extensiontask"
 require "rake/testtask"
 
 spec = eval(File.read('bigdecimal.gemspec'))
-Rake::ExtensionTask.new('bigdecimal', spec)
+if RUBY_ENGINE == 'jruby'
+  # JRuby's extension is included with JRuby currently
+  task :compile do; end
+else
+  Rake::ExtensionTask.new('bigdecimal', spec)
+end
 
 Rake::TestTask.new do |t|
   t.libs << 'test/lib'

--- a/bigdecimal.gemspec
+++ b/bigdecimal.gemspec
@@ -12,17 +12,8 @@ Gem::Specification.new do |s|
   s.licenses       = ["Ruby", "bsd-2-clause"]
 
   s.require_paths = %w[lib]
-  s.extensions    = %w[ext/bigdecimal/extconf.rb]
   s.files         = %w[
     bigdecimal.gemspec
-    ext/bigdecimal/bigdecimal.c
-    ext/bigdecimal/bigdecimal.h
-    ext/bigdecimal/bits.h
-    ext/bigdecimal/feature.h
-    ext/bigdecimal/missing.c
-    ext/bigdecimal/missing.h
-    ext/bigdecimal/missing/dtoa.c
-    ext/bigdecimal/static_assert.h
     lib/bigdecimal.rb
     lib/bigdecimal/jacobian.rb
     lib/bigdecimal/ludcmp.rb
@@ -33,6 +24,21 @@ Gem::Specification.new do |s|
     sample/nlsolve.rb
     sample/pi.rb
   ]
+  if Gem::Platform === s.platform and s.platform =~ 'java' or RUBY_ENGINE == 'jruby'
+    s.platform      = 'java'
+  else
+    s.extensions    = %w[ext/bigdecimal/extconf.rb]
+    s.files += %w[
+      ext/bigdecimal/bigdecimal.c
+      ext/bigdecimal/bigdecimal.h
+      ext/bigdecimal/bits.h
+      ext/bigdecimal/feature.h
+      ext/bigdecimal/missing.c
+      ext/bigdecimal/missing.h
+      ext/bigdecimal/missing/dtoa.c
+      ext/bigdecimal/static_assert.h
+    ]
+  end
 
   s.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 end

--- a/lib/bigdecimal.rb
+++ b/lib/bigdecimal.rb
@@ -1,1 +1,5 @@
-require 'bigdecimal.so'
+if RUBY_ENGINE == 'jruby'
+  JRuby::Util.load_ext("org.jruby.ext.bigdecimal.BigDecimalLibrary")
+else
+  require 'bigdecimal.so'
+end


### PR DESCRIPTION
JRuby currently ships its own internal bigdecimal extension as part of the core libraries. In order for users to be able to add bigdecimal to their Gemfile or gem dependencies, we need to stub out the C extension and just load the extension shipped with JRuby.

In the future we will try to move our BigDecimal implementation into the gem, but for now this is the simplest way to make it installable on JRuby.

See #169