### PR TITLE
Fix the license name [ci skip]

### DIFF
--- a/bigdecimal.gemspec
+++ b/bigdecimal.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary       = "Arbitrary-precision decimal floating-point number library."
   s.description   = "This library provides arbitrary-precision decimal floating-point number class."
   s.homepage      = "https://github.com/ruby/bigdecimal"
-  s.licenses       = ["Ruby", "bsd-2-clause"]
+  s.licenses       = ["Ruby", "BSD-2-Clause"]
 
   s.require_paths = %w[lib]
   s.files         = %w[


### PR DESCRIPTION
```
$ gem build bigdecimal.gemspec
WARNING:  license value 'BSD-2-clause' is invalid.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
Did you mean 'BSD-2-Clause'?
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
```