### PR TITLE
Bump up to 3.1.4

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -31,7 +31,7 @@
 #include "bits.h"
 #include "static_assert.h"
 
-#define BIGDECIMAL_VERSION "3.1.3"
+#define BIGDECIMAL_VERSION "3.1.4"
 
 /* #define ENABLE_NUMERIC_STRING */
 


### PR DESCRIPTION
ruby/bigdecimal#187 has changed a behavior and ruby/spec also needed a follow up at ruby/ruby@0d8ef62fc293dc04110f36382a7e8bddec6aee15.
However, because bigdecimal is a separate gem and can be updated in older versions of ruby, `RUBY_VERSION` is not appropriate for this guard.
That means it needs bumped up `BigDecimal::VERSION`.