### PR TITLE
fix: typo in document comments of `f_BigDecimal` function

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -3722,7 +3722,7 @@ rb_convert_to_BigDecimal(VALUE val, size_t digs, int raise_exception)
  *  - Other type:
  *
  *    - Raises an exception if keyword argument +exception+ is +true+.
- *    - Returns +nil+ if keyword argument +exception+ is +true+.
+ *    - Returns +nil+ if keyword argument +exception+ is +false+.
  *
  *  Raises an exception if +value+ evaluates to a Float
  *  and +digits+ is larger than Float::DIG + 1.


### PR DESCRIPTION
The [documents for `Kernel#BigDecimal` method](https://ruby-doc.org/3.2.1/exts/bigdecimal/Kernel.html#method-i-BigDecimal) has a typo in the second line from the bottom:

> Returns `nil` if keyword argument `exception` is `true`.

which should be:

> Returns `nil` if keyword argument `exception` is `false`.