### PR TITLE
Remove set but unused variable

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -7171,7 +7171,6 @@ VpSqrt(Real *y, Real *x)
     Real *r = NULL;
     size_t y_prec;
     SIGNED_VALUE n, e;
-    SIGNED_VALUE prec;
     ssize_t nr;
     double val;
 
@@ -7209,12 +7208,6 @@ VpSqrt(Real *y, Real *x)
 
     nr = 0;
     y_prec = y->MaxPrec;
-
-    prec = x->exponent - (ssize_t)y_prec;
-    if (x->exponent > 0)
-	++prec;
-    else
-	--prec;
 
     VpVtoD(&val, &e, x);    /* val <- x  */
     e /= (SIGNED_VALUE)BASE_FIG;


### PR DESCRIPTION
This `prec` has not been used since 1f5c46dbdd1c53542ab7d37febc1a6f19b245b25.