### PR TITLE
Bump up to 3.1.5

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -31,7 +31,7 @@
 #include "bits.h"
 #include "static_assert.h"
 
-#define BIGDECIMAL_VERSION "3.1.4"
+#define BIGDECIMAL_VERSION "3.1.5"
 
 /* #define ENABLE_NUMERIC_STRING */
 


### PR DESCRIPTION
https://github.com/ruby/bigdecimal/pull/264#issuecomment-1626935510

Default gems need to bump up the version when a behavior change affects rubyspec tests.
