### PR TITLE
Remove TruffleRuby from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
-      engine: cruby-truffleruby
+      engine: cruby
       min_version: 2.5
       versions: '["debug"]'
 


### PR DESCRIPTION
TruffleRuby is broken with `test_bsearch_for_bigdecimal`.

https://github.com/ruby/bigdecimal/actions/runs/5539953890/job/15003817415