### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/bigdecimal

### DIFF
--- a/bigdecimal.gemspec
+++ b/bigdecimal.gemspec
@@ -51,4 +51,6 @@ Gem::Specification.new do |s|
   end
 
   s.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
+
+  s.metadata["changelog_uri"] = s.homepage + "/blob/master/CHANGES.md"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/bigdecimal which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/