### PR TITLE
Add LICENSE file to gem files

### DIFF
--- a/bigdecimal.gemspec
+++ b/bigdecimal.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = %w[lib]
   s.files         = %w[
+    LICENSE
     bigdecimal.gemspec
     lib/bigdecimal.rb
     lib/bigdecimal/jacobian.rb


### PR DESCRIPTION
Adding a `LICENSE` file to the bundled gem package is common practice. This way, automated OSS license compliance tools will be able to collect the full text of the license.