### PR TITLE
Workaround for test-bundled-gems at ruby/ruby repo

### DIFF
--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1768,11 +1768,7 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_split_under_gc_stress
     bug3258 = '[ruby-dev:41213]'
     expect = 10.upto(20).map{|i|[1, "1", 10, i+1].inspect}
-    # for test-bundled-gems in ruby/ruby repository
-    extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
-    opts = ["-rbigdecimal", "--disable-gems"]
-    opts.unshift "-I#{extension_paths}" unless extension_paths.empty?
-    assert_in_out_err(opts, <<-EOS, expect, [], bug3258)
+    assert_in_out_err(["-I#{$LOAD_PATH.join(":")}", "-rbigdecimal", "--disable-gems"], <<-EOS, expect, [], bug3258)
     GC.stress = true
     10.upto(20) do |i|
       p BigDecimal("1"+"0"*i).split
@@ -1781,11 +1777,7 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_coerce_under_gc_stress
-    # for test-bundled-gems in ruby/ruby repository
-    extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
-    opts = ["-rbigdecimal", "--disable-gems"]
-    opts.unshift "-I#{extension_paths}" unless extension_paths.empty?
-    assert_in_out_err(opts, <<-EOS, [], [])
+    assert_in_out_err(["-I#{$LOAD_PATH.join(":")}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
       expect = ":too_long_to_embed_as_string can't be coerced into BigDecimal"
       b = BigDecimal("1")
       GC.stress = true
@@ -1892,11 +1884,7 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_BigMath_exp_under_gc_stress
-    # for test-bundled-gems in ruby/ruby repository
-    extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
-    opts = ["-rbigdecimal", "--disable-gems"]
-    opts.unshift "-I#{extension_paths}" unless extension_paths.empty?
-    assert_in_out_err(opts, <<-EOS, [], [])
+    assert_in_out_err(["-I#{$LOAD_PATH.join(":")}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
       expect = ":too_long_to_embed_as_string can't be coerced into BigDecimal"
       10.times do
         begin
@@ -2038,11 +2026,7 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_BigMath_log_under_gc_stress
-    # for test-bundled-gems in ruby/ruby repository
-    extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
-    opts = ["-rbigdecimal", "--disable-gems"]
-    opts.unshift "-I#{extension_paths}" unless extension_paths.empty?
-    assert_in_out_err(opts, <<-EOS, [], [])
+    assert_in_out_err(["-I#{$LOAD_PATH.join(":")}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
       expect = ":too_long_to_embed_as_string can't be coerced into BigDecimal"
       10.times do
         begin
@@ -2089,11 +2073,7 @@ class TestBigDecimal < Test::Unit::TestCase
   end if RUBY_VERSION < '2.5' # mathn was removed from Ruby 2.5
 
   def test_bug6406
-    # for test-bundled-gems in ruby/ruby repository
-    extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
-    opts = ["-rbigdecimal", "--disable-gems"]
-    opts.unshift "-I#{extension_paths}" unless extension_paths.empty?
-    assert_in_out_err(opts, <<-EOS, [], [])
+    assert_in_out_err(["-I#{$LOAD_PATH.join(":")}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
     Thread.current.keys.to_s
     EOS
   end

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1770,7 +1770,9 @@ class TestBigDecimal < Test::Unit::TestCase
     expect = 10.upto(20).map{|i|[1, "1", 10, i+1].inspect}
     # for test-bundled-gems in ruby/ruby repository
     extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
-    assert_in_out_err(["-I#{extension_paths}", "-rbigdecimal", "--disable-gems"], <<-EOS, expect, [], bug3258)
+    opts = ["-rbigdecimal", "--disable-gems"]
+    opts.unshift "-I#{extension_paths}" unless extension_paths.empty?
+    assert_in_out_err(opts, <<-EOS, expect, [], bug3258)
     GC.stress = true
     10.upto(20) do |i|
       p BigDecimal("1"+"0"*i).split
@@ -1781,7 +1783,9 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_coerce_under_gc_stress
     # for test-bundled-gems in ruby/ruby repository
     extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
-    assert_in_out_err(["-I#{extension_paths}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
+    opts = ["-rbigdecimal", "--disable-gems"]
+    opts.unshift "-I#{extension_paths}" unless extension_paths.empty?
+    assert_in_out_err(opts, <<-EOS, [], [])
       expect = ":too_long_to_embed_as_string can't be coerced into BigDecimal"
       b = BigDecimal("1")
       GC.stress = true
@@ -1890,7 +1894,9 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_BigMath_exp_under_gc_stress
     # for test-bundled-gems in ruby/ruby repository
     extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
-    assert_in_out_err(["-I#{extension_paths}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
+    opts = ["-rbigdecimal", "--disable-gems"]
+    opts.unshift "-I#{extension_paths}" unless extension_paths.empty?
+    assert_in_out_err(opts, <<-EOS, [], [])
       expect = ":too_long_to_embed_as_string can't be coerced into BigDecimal"
       10.times do
         begin
@@ -2034,7 +2040,9 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_BigMath_log_under_gc_stress
     # for test-bundled-gems in ruby/ruby repository
     extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
-    assert_in_out_err(["-I#{extension_paths}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
+    opts = ["-rbigdecimal", "--disable-gems"]
+    opts.unshift "-I#{extension_paths}" unless extension_paths.empty?
+    assert_in_out_err(opts, <<-EOS, [], [])
       expect = ":too_long_to_embed_as_string can't be coerced into BigDecimal"
       10.times do
         begin
@@ -2083,7 +2091,9 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_bug6406
     # for test-bundled-gems in ruby/ruby repository
     extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
-    assert_in_out_err(["-I#{extension_paths}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
+    opts = ["-rbigdecimal", "--disable-gems"]
+    opts.unshift "-I#{extension_paths}" unless extension_paths.empty?
+    assert_in_out_err(opts, <<-EOS, [], [])
     Thread.current.keys.to_s
     EOS
   end

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1768,7 +1768,8 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_split_under_gc_stress
     bug3258 = '[ruby-dev:41213]'
     expect = 10.upto(20).map{|i|[1, "1", 10, i+1].inspect}
-    assert_in_out_err(["-I#{$LOAD_PATH.join(":")}", "-rbigdecimal", "--disable-gems"], <<-EOS, expect, [], bug3258)
+    paths = $LOAD_PATH.map{|path| "-I#{path}" }
+    assert_in_out_err([*paths, "-rbigdecimal", "--disable-gems"], <<-EOS, expect, [], bug3258)
     GC.stress = true
     10.upto(20) do |i|
       p BigDecimal("1"+"0"*i).split
@@ -1777,7 +1778,8 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_coerce_under_gc_stress
-    assert_in_out_err(["-I#{$LOAD_PATH.join(":")}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
+    paths = $LOAD_PATH.map{|path| "-I#{path}" }
+    assert_in_out_err([*paths, "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
       expect = ":too_long_to_embed_as_string can't be coerced into BigDecimal"
       b = BigDecimal("1")
       GC.stress = true
@@ -1884,7 +1886,8 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_BigMath_exp_under_gc_stress
-    assert_in_out_err(["-I#{$LOAD_PATH.join(":")}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
+    paths = $LOAD_PATH.map{|path| "-I#{path}" }
+    assert_in_out_err([*paths, "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
       expect = ":too_long_to_embed_as_string can't be coerced into BigDecimal"
       10.times do
         begin
@@ -2026,7 +2029,8 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_BigMath_log_under_gc_stress
-    assert_in_out_err(["-I#{$LOAD_PATH.join(":")}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
+    paths = $LOAD_PATH.map{|path| "-I#{path}" }
+    assert_in_out_err([*paths, "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
       expect = ":too_long_to_embed_as_string can't be coerced into BigDecimal"
       10.times do
         begin
@@ -2073,7 +2077,8 @@ class TestBigDecimal < Test::Unit::TestCase
   end if RUBY_VERSION < '2.5' # mathn was removed from Ruby 2.5
 
   def test_bug6406
-    assert_in_out_err(["-I#{$LOAD_PATH.join(":")}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
+    paths = $LOAD_PATH.map{|path| "-I#{path}" }
+    assert_in_out_err([*paths, "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
     Thread.current.keys.to_s
     EOS
   end
@@ -2283,7 +2288,8 @@ class TestBigDecimal < Test::Unit::TestCase
 
   def assert_no_memory_leak(code, *rest, **opt)
     code = "8.times {20_000.times {begin #{code}; rescue NoMemoryError; end}; GC.start}"
-    super(["-I#{$LOAD_PATH.join(":")}", "-rbigdecimal"],
+    paths = $LOAD_PATH.map{|path| "-I#{path}" }
+    super([*paths, "-rbigdecimal"],
           "b = BigDecimal('10'); b.nil?; " \
           "GC.add_stress_to_class(BigDecimal); "\
           "#{code}", code, *rest, rss: true, limit: 1.1, **opt)

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1768,7 +1768,9 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_split_under_gc_stress
     bug3258 = '[ruby-dev:41213]'
     expect = 10.upto(20).map{|i|[1, "1", 10, i+1].inspect}
-    assert_in_out_err(%w[-rbigdecimal --disable-gems], <<-EOS, expect, [], bug3258)
+    # for test-bundled-gems in ruby/ruby repository
+    extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
+    assert_in_out_err(["-I#{extension_paths}", "-rbigdecimal", "--disable-gems"], <<-EOS, expect, [], bug3258)
     GC.stress = true
     10.upto(20) do |i|
       p BigDecimal("1"+"0"*i).split
@@ -1777,7 +1779,9 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_coerce_under_gc_stress
-    assert_in_out_err(%w[-rbigdecimal --disable-gems], <<-EOS, [], [])
+    # for test-bundled-gems in ruby/ruby repository
+    extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
+    assert_in_out_err(["-I#{extension_paths}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
       expect = ":too_long_to_embed_as_string can't be coerced into BigDecimal"
       b = BigDecimal("1")
       GC.stress = true
@@ -1884,7 +1888,9 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_BigMath_exp_under_gc_stress
-    assert_in_out_err(%w[-rbigdecimal --disable-gems], <<-EOS, [], [])
+    # for test-bundled-gems in ruby/ruby repository
+    extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
+    assert_in_out_err(["-I#{extension_paths}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
       expect = ":too_long_to_embed_as_string can't be coerced into BigDecimal"
       10.times do
         begin
@@ -2026,7 +2032,9 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_BigMath_log_under_gc_stress
-    assert_in_out_err(%w[-rbigdecimal --disable-gems], <<-EOS, [], [])
+    # for test-bundled-gems in ruby/ruby repository
+    extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
+    assert_in_out_err(["-I#{extension_paths}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
       expect = ":too_long_to_embed_as_string can't be coerced into BigDecimal"
       10.times do
         begin
@@ -2073,7 +2081,9 @@ class TestBigDecimal < Test::Unit::TestCase
   end if RUBY_VERSION < '2.5' # mathn was removed from Ruby 2.5
 
   def test_bug6406
-    assert_in_out_err(%w[-rbigdecimal --disable-gems], <<-EOS, [], [])
+    # for test-bundled-gems in ruby/ruby repository
+    extension_paths = Dir.glob(File.expand_path('../../../../../.bundle/extensions', __dir__) + '/**/*/bigdecimal-*').join(":")
+    assert_in_out_err(["-I#{extension_paths}", "-rbigdecimal", "--disable-gems"], <<-EOS, [], [])
     Thread.current.keys.to_s
     EOS
   end

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -2290,10 +2290,6 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   if EnvUtil.gc_stress_to_class?
-    def test_no_memory_leak_allocate
-      assert_no_memory_leak("BigDecimal.allocate")
-    end
-
     def test_no_memory_leak_BigDecimal
       assert_no_memory_leak("BigDecimal('10')")
       assert_no_memory_leak("BigDecimal(b)")

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -2283,7 +2283,7 @@ class TestBigDecimal < Test::Unit::TestCase
 
   def assert_no_memory_leak(code, *rest, **opt)
     code = "8.times {20_000.times {begin #{code}; rescue NoMemoryError; end}; GC.start}"
-    super(["-rbigdecimal"],
+    super(["-I#{$LOAD_PATH.join(":")}", "-rbigdecimal"],
           "b = BigDecimal('10'); b.nil?; " \
           "GC.add_stress_to_class(BigDecimal); "\
           "#{code}", code, *rest, rss: true, limit: 1.1, **opt)

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -2294,10 +2294,6 @@ class TestBigDecimal < Test::Unit::TestCase
       assert_no_memory_leak("BigDecimal.allocate")
     end
 
-    def test_no_memory_leak_initialize
-      assert_no_memory_leak("BigDecimal()")
-    end
-
     def test_no_memory_leak_BigDecimal
       assert_no_memory_leak("BigDecimal('10')")
       assert_no_memory_leak("BigDecimal(b)")


### PR DESCRIPTION
There is no way to load `bigdecimal` extension in `assert_in_out_err` with `make test-bundled-gems` of ruby/ruby repository.

I added extension directory for that explicitly. I know this is ad-hoc solution. We should provide these paths to like `assert_in_out_err` assertions in `ruby/ruby` side.