### PR TITLE
Use macos-arm-oss and latest versions for test and benchmark CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,8 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        - macos-11
+        - macos-latest
+        - macos-arm-oss
         - windows-latest
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         os:
         - ubuntu-latest
         - macos-latest
+        - macos-arm-oss
         - windows-latest
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         - { os: windows-latest , ruby: mingw }
         - { os: windows-latest , ruby: mswin }
         exclude:
+        - { os: macos-arm-oss  , ruby: "2.5" }
         - { os: windows-latest , ruby: debug }
         - { os: windows-latest , ruby: truffleruby }
         - { os: windows-latest , ruby: truffleruby-head }


### PR DESCRIPTION
macOS 11 is already EOL. I update CI matrix with `macos-arm-oss` and `macos-latest`. After that, we can test with macos-13 and Apple Silicon.