### PR TITLE
Rename `rake spec` with `rake test` in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ TODO: Write usage instructions here
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies.
-Then, run `rake spec` to run the tests.
+Then, run `rake test` to run the tests.
 You can also run `bin/console` for an interactive prompt that
 will allow you to experiment.
 


### PR DESCRIPTION
`rake spec` is not defined in Rake tasks (`rake -T`).

`rake test` runs the tests.

This updates the documentation to help newcomers to run the test suite locally.