### PR TITLE
Restore TruffleRuby on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
-      engine: cruby
+      engine: cruby-truffleruby
       min_version: 2.5
       versions: '["debug"]'
 


### PR DESCRIPTION
TruffleRuby was removed on CI in #266. But the issue was fixed in the TruffleRuby 24.0 release.