### PR TITLE
Extend docs for round(0) [ci skip]

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2467,7 +2467,7 @@ BigDecimal_fix(VALUE self)
  *
  *	BigDecimal('3.14159').round(2).class.name #=> "BigDecimal"
  *	BigDecimal('3.14159').round.class.name #=> "Integer"
- *      BigDecimal('3.14159').round(0).class.name #=> "Integer"
+ *	BigDecimal('3.14159').round(0).class.name #=> "Integer"
  *
  * If n is specified and positive, the fractional part of the result has no
  * more than that many digits.

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2459,7 +2459,7 @@ BigDecimal_fix(VALUE self)
  * round(n, mode)
  *
  * Round to the nearest integer (by default), returning the result as a
- * BigDecimal if n is specified, or as an Integer if it isn't.
+ * BigDecimal if n is specified and positive, or as an Integer if it isn't.
  *
  *	BigDecimal('3.14159').round #=> 3
  *	BigDecimal('8.7').round #=> 9
@@ -2467,6 +2467,7 @@ BigDecimal_fix(VALUE self)
  *
  *	BigDecimal('3.14159').round(2).class.name #=> "BigDecimal"
  *	BigDecimal('3.14159').round.class.name #=> "Integer"
+ *      BigDecimal('3.14159').round(0).class.name #=> "Integer"
  *
  * If n is specified and positive, the fractional part of the result has no
  * more than that many digits.


### PR DESCRIPTION
Since #170, `big_decimal.round(0)` returns an Integer. This was surprising to me, as the documentation does not specify the behavior for this case. (It could even be seen as misleading / wrong.)