### PR TITLE
Use macos-14 instead of macos-arm-oss

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,7 @@ jobs:
         os:
         - ubuntu-latest
         - macos-latest
-        - macos-arm-oss
+        - macos-14
         - windows-latest
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         os:
         - ubuntu-latest
         - macos-latest
-        - macos-arm-oss
+        - macos-14
         - windows-latest
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         include:
@@ -36,7 +36,7 @@ jobs:
         - { os: windows-latest , ruby: mswin }
         exclude:
         - { os: macos-latest   , ruby: "2.5" }
-        - { os: macos-arm-oss  , ruby: "2.5" }
+        - { os: macos-14  , ruby: "2.5" }
         - { os: windows-latest , ruby: debug }
         - { os: windows-latest , ruby: truffleruby }
         - { os: windows-latest , ruby: truffleruby-head }


### PR DESCRIPTION
Unfortunately, we lost macos-arm-oss runner from ruby org.