### PR TITLE
Fix extra semicolon outside of a function in `NO_SANITIZE`

### DIFF
--- a/ext/bigdecimal/missing.c
+++ b/ext/bigdecimal/missing.c
@@ -15,7 +15,8 @@
     _Pragma("GCC diagnostic push") \
     _Pragma("GCC diagnostic ignored \"-Wattributes\"") \
     __attribute__((__no_sanitize__(x))) y; \
-    _Pragma("GCC diagnostic pop")
+    _Pragma("GCC diagnostic pop") \
+    y
 #endif
 
 #undef strtod


### PR DESCRIPTION
See ruby/ruby@8ba2c3109c0f80f285b8db2fed10d8f5f026c208