### PR TITLE
Fix 'maybe_unused' attribute in 2.x

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -65,7 +65,11 @@ static ID id_eq;
 static ID id_half;
 
 /* MACRO's to guard objects from GC by keeping them in stack */
+#ifdef RBIMPL_ATTR_MAYBE_UNUSED
+#define ENTER(n) RBIMPL_ATTR_MAYBE_UNUSED() volatile VALUE vStack[n];int iStack=0
+#else
 #define ENTER(n) volatile VALUE RB_UNUSED_VAR(vStack[n]);int iStack=0
+#endif
 #define PUSH(x)  (vStack[iStack++] = (VALUE)(x))
 #define SAVE(p)  PUSH((p)->obj)
 #define GUARD_OBJ(p,y) ((p)=(y), SAVE(p))


### PR DESCRIPTION
Backported fix from https://github.com/ruby/bigdecimal/commit/6d510e47bce2ba4dbff4c48c26ee8d5cd8de1758 for 2.x support