### PR TITLE
Cast divmod quotient to int

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2172,8 +2172,8 @@ BigDecimal_divmod(VALUE self, VALUE r)
     Real *div = NULL, *mod = NULL;
 
     if (BigDecimal_DoDivmod(self, r, &div, &mod)) {
-	SAVE(div); SAVE(mod);
-        return rb_assoc_new(VpCheckGetValue(div), VpCheckGetValue(mod));
+	      SAVE(div); SAVE(mod);
+        return rb_assoc_new(BigDecimal_to_i(VpCheckGetValue(div)), VpCheckGetValue(mod));
     }
     return DoSomeOne(self,r,rb_intern("divmod"));
 }

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1052,6 +1052,10 @@ class TestBigDecimal < Test::Unit::TestCase
 
     assert_equal([0, 0], BigDecimal("0").divmod(2))
 
+    quotient, reminder =  BigDecimal("10").divmod(3)
+    assert_kind_of(Integer, quotient)
+    assert_kind_of(BigDecimal, reminder)
+
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
     assert_raise(ZeroDivisionError){BigDecimal("0").divmod(0)}
   end


### PR DESCRIPTION
Fixes https://github.com/ruby/bigdecimal/issues/262
(description in TBD)