### PR TITLE
Fix spec NoMethodError message for .allocator on truffle Ruby

### DIFF
--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -297,7 +297,7 @@ class TestBigDecimal < Test::Unit::TestCase
 
   def test_s_allocate
     if RUBY_ENGINE == "truffleruby"
-      assert_raise_with_message(NoMethodError, /undefined.+allocate.+for BigDecimal/) { BigDecimal.allocate }
+      assert_raise_with_message(NoMethodError, /undefined.+allocate.+for.+BigDecimal/) { BigDecimal.allocate }
     else
       assert_raise_with_message(TypeError, /allocator undefined for BigDecimal/) { BigDecimal.allocate }
     end


### PR DESCRIPTION
I've noticed test failures on truffleruby-head: https://github.com/ruby/bigdecimal/actions/runs/13139256664/job/36662137135?pr=312
```
 Failure: test_s_allocate(TestBigDecimal):
  Expected Exception(NoMethodError) was raised, but the message doesn't match.
  Expected /undefined.+allocate.+for BigDecimal/ to match "undefined method `__allocate__' for class BigDecimal".
  <nil> is not true.
/home/runner/.rubies/truffleruby-head/lib/gems/gems/test-unit-ruby-core-1.0.6/lib/core_assertions.rb:540:in `assert'
/home/runner/.rubies/truffleruby-head/lib/gems/gems/test-unit-ruby-core-1.0.6/lib/core_assertions.rb:511:in `assert_raise_with_message'
/home/runner/work/bigdecimal/bigdecimal/test/bigdecimal/test_bigdecimal.rb:300:in `test_s_allocate'
/home/runner/.rubies/truffleruby-head/lib/gems/gems/test-unit-3.6.7/lib/test/unit/ui/console/testrunner.rb:324: warning: too many arguments for format string
     297: 
     298:   def test_s_allocate
     299:     if RUBY_ENGINE == "truffleruby"
  => 300:       assert_raise_with_message(NoMethodError, /undefined.+allocate.+for BigDecimal/) { BigDecimal.allocate }
     301:     else
     302:       assert_raise_with_message(TypeError, /allocator undefined for BigDecimal/) { BigDecimal.allocate }
     303:     end
``` 

I believe we can safely relax the expectation without losing anything and the test will pass on truffle.