### PR TITLE
Allow BigDecimal accept Float without precision

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -3458,11 +3458,7 @@ rb_float_convert_to_BigDecimal(VALUE val, size_t digs, int raise_exception)
     }
 
     if (digs == SIZE_MAX) {
-        if (!raise_exception)
-            return Qnil;
-        rb_raise(rb_eArgError,
-                 "can't omit precision for a %"PRIsVALUE".",
-                 CLASS_OF(val));
+        digs = 0;
     }
     else if (digs > BIGDECIMAL_DOUBLE_FIGURES) {
         if (!raise_exception)
@@ -3712,12 +3708,12 @@ rb_convert_to_BigDecimal(VALUE val, size_t digs, int raise_exception)
  *
  *  - Integer, Float, Rational, Complex, or BigDecimal: converted directly:
  *
- *      # Integer, Complex, or BigDecimal value does not require ndigits; ignored if given.
+ *      # Integer, Complex, Float, or BigDecimal value does not require ndigits; ignored if given.
  *      BigDecimal(2)                     # => 0.2e1
  *      BigDecimal(Complex(2, 0))         # => 0.2e1
  *      BigDecimal(BigDecimal(2))         # => 0.2e1
- *      # Float or Rational value requires ndigits.
- *      BigDecimal(2.0, 0)                # => 0.2e1
+ *      BigDecimal(2.0)                   # => 0.2e1
+ *      # Rational value requires ndigits.
  *      BigDecimal(Rational(2, 1), 0)     # => 0.2e1
  *
  *  - String: converted by parsing if it contains an integer or floating-point literal;

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -664,8 +664,8 @@ BigDecimal_precision(VALUE self)
  *    BigDecimal("1").scale         # => 0
  *    BigDecimal("1.1").scale       # => 1
  *    BigDecimal("3.1415").scale    # => 4
- *    BigDecimal("-1e20").precision # => 0
- *    BigDecimal("1e-20").precision # => 20
+ *    BigDecimal("-1e20").scale     # => 0
+ *    BigDecimal("1e-20").scale     # => 20
  *    BigDecimal("Infinity").scale  # => 0
  *    BigDecimal("-Infinity").scale # => 0
  *    BigDecimal("NaN").scale       # => 0

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -166,7 +166,8 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(BigDecimal("0.1235"), BigDecimal(0.1234567, 4))
     assert_equal(BigDecimal("-0.1235"), BigDecimal(-0.1234567, 4))
     assert_equal(BigDecimal("0.01"), BigDecimal(0.01, Float::DIG + 1))
-    assert_raise_with_message(ArgumentError, "can't omit precision for a Float.") { BigDecimal(4.2) }
+    assert_nothing_raised { BigDecimal(4.2) }
+    assert_equal(BigDecimal(4.2), BigDecimal('4.2'))
     assert_raise(ArgumentError) { BigDecimal(0.1, Float::DIG + 2) }
     assert_nothing_raised { BigDecimal(0.1, Float::DIG + 1) }
 
@@ -242,10 +243,10 @@ class TestBigDecimal < Test::Unit::TestCase
       assert_equal(nil, BigDecimal(42.quo(7), exception: false))
     }
     assert_raise(ArgumentError) {
-      BigDecimal(4.2, exception: true)
+      BigDecimal(4.2, Float::DIG + 2, exception: true)
     }
     assert_nothing_raised(ArgumentError) {
-      assert_equal(nil, BigDecimal(4.2, exception: false))
+      assert_equal(nil, BigDecimal(4.2, Float::DIG + 2, exception: false))
     }
     # TODO: support conversion from complex
     # assert_raise(RangeError) {

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -168,6 +168,8 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(BigDecimal("0.01"), BigDecimal(0.01, Float::DIG + 1))
     assert_nothing_raised { BigDecimal(4.2) }
     assert_equal(BigDecimal(4.2), BigDecimal('4.2'))
+    assert_equal(BigDecimal("0.12345"), BigDecimal(0.12345, 0))
+    assert_equal(BigDecimal("0.12345"), BigDecimal(0.12345))
     assert_raise(ArgumentError) { BigDecimal(0.1, Float::DIG + 2) }
     assert_nothing_raised { BigDecimal(0.1, Float::DIG + 1) }
 


### PR DESCRIPTION
Make sure that conversion from a Float works consistently with the conversion from a string representing that float.

Current `master` state:
```
pry(main)> BigDecimal(1.2)
ArgumentError: can't omit precision for a Float.
from (pry):22:in `BigDecimal'
pry(main)> BigDecimal('1.2')
=> 0.12e1
```

After this changes:
```
pry(main)> BigDecimal(1.2)
=> 0.12e1
pry(main)> BigDecimal('1.2')
=> 0.12e1
```

When precision is omitted it's set to `0`.

Fixes https://github.com/ruby/bigdecimal/issues/213
Blocked by https://github.com/ruby/bigdecimal/pull/313