### PR TITLE
Add a precision assertion to BigMath test

### DIFF
--- a/test/bigdecimal/helper.rb
+++ b/test/bigdecimal/helper.rb
@@ -36,4 +36,23 @@ module TestBigDecimalBase
   ensure
     GC.stress = stress
   end
+
+  # Asserts that the calculation of the given block converges to some value
+  # with a precision of at least n digits.
+
+  def assert_fixed_point_precision(n = 100)
+    value = yield(n)
+    expected = yield(2 * n)
+    precision = -(value - expected).exponent
+    assert(value != expected, "Unable to estimate precision for exact value")
+    assert(precision >= n, "Precision is not enough: #{precision} < #{n}")
+  end
+
+  def assert_relative_precision(n = 100)
+    value = yield(n)
+    expected = yield(2 * n)
+    precision = -(value.div(expected, 2 * n) - 1).exponent
+    assert(value != expected, "Unable to estimate precision for exact value")
+    assert(precision >= n, "Precision is not enough: #{precision} < #{n}")
+  end
 end

--- a/test/bigdecimal/test_bigmath.rb
+++ b/test/bigdecimal/test_bigmath.rb
@@ -6,29 +6,12 @@ class TestBigMath < Test::Unit::TestCase
   include TestBigDecimalBase
   include BigMath
   N = 20
-  N_LARGE = 100
   # SQRT in 116 (= 100 + double_fig) digits
   SQRT2 = BigDecimal("1.4142135623730950488016887242096980785696718753769480731766797379907324784621070388503875343276415727350138462309123")
   SQRT3 = BigDecimal("1.7320508075688772935274463415058723669428052538103806280558069794519330169088000370811461867572485756756261414154067")
   PINF = BigDecimal("+Infinity")
   MINF = BigDecimal("-Infinity")
   NAN = BigDecimal("NaN")
-
-  def assert_fixed_point_precision(n = N_LARGE)
-    value = yield(n)
-    expected = yield(2 * n)
-    precision = -(value - expected).exponent
-    assert(value != expected, "Unable to estimate precision for exact value")
-    assert(precision >= n, "Precision is not enough: #{precision} < #{n}")
-  end
-
-  def assert_relative_precision(n = N_LARGE)
-    value = yield(n)
-    expected = yield(2 * n)
-    precision = -(value / expected - 1).exponent
-    assert(value != expected, "Unable to estimate precision for exact value")
-    assert(precision >= n, "Precision is not enough: #{precision} < #{n}")
-  end
 
   def test_const
     assert_in_delta(Math::PI, PI(N))

--- a/test/bigdecimal/test_bigmath.rb
+++ b/test/bigdecimal/test_bigmath.rb
@@ -6,9 +6,29 @@ class TestBigMath < Test::Unit::TestCase
   include TestBigDecimalBase
   include BigMath
   N = 20
+  N_LARGE = 100
+  # SQRT in 116 (= 100 + double_fig) digits
+  SQRT2 = BigDecimal("1.4142135623730950488016887242096980785696718753769480731766797379907324784621070388503875343276415727350138462309123")
+  SQRT3 = BigDecimal("1.7320508075688772935274463415058723669428052538103806280558069794519330169088000370811461867572485756756261414154067")
   PINF = BigDecimal("+Infinity")
   MINF = BigDecimal("-Infinity")
   NAN = BigDecimal("NaN")
+
+  def assert_fixed_point_precision(n = N_LARGE)
+    value = yield(n)
+    expected = yield(2 * n)
+    precision = -(value - expected).exponent
+    assert(value != expected, "Unable to estimate precision for exact value")
+    assert(precision >= n, "Precision is not enough: #{precision} < #{n}")
+  end
+
+  def assert_relative_precision(n = N_LARGE)
+    value = yield(n)
+    expected = yield(2 * n)
+    precision = -(value / expected - 1).exponent
+    assert(value != expected, "Unable to estimate precision for exact value")
+    assert(precision >= n, "Precision is not enough: #{precision} < #{n}")
+  end
 
   def test_const
     assert_in_delta(Math::PI, PI(N))
@@ -23,6 +43,11 @@ class TestBigMath < Test::Unit::TestCase
     assert_raise(FloatDomainError) {sqrt(BigDecimal("-1.0"), N)}
     assert_raise(FloatDomainError) {sqrt(NAN, N)}
     assert_raise(FloatDomainError) {sqrt(PINF, N)}
+    assert_in_delta(SQRT2, sqrt(BigDecimal("2"), 100), BigDecimal("1e-100"))
+    assert_in_delta(SQRT3, sqrt(BigDecimal("3"), 100), BigDecimal("1e-100"))
+    assert_relative_precision {|n| sqrt(BigDecimal("2"), n) }
+    assert_relative_precision {|n| sqrt(BigDecimal("2e-50"), n) }
+    assert_relative_precision {|n| sqrt(BigDecimal("2e50"), n) }
   end
 
   def test_sin
@@ -37,6 +62,13 @@ class TestBigMath < Test::Unit::TestCase
     assert_in_delta(0.0, sin(PI(N) * 21, N))
     assert_in_delta(0.0, sin(PI(N) * 30, N))
     assert_in_delta(-1.0, sin(PI(N) * BigDecimal("301.5"), N))
+    assert_in_delta(BigDecimal('0.5'), sin(PI(100) / 6, 100), BigDecimal("1e-100"))
+    assert_in_delta(SQRT3 / 2, sin(PI(100) / 3, 100), BigDecimal("1e-100"))
+    assert_in_delta(SQRT2 / 2, sin(PI(100) / 4, 100), BigDecimal("1e-100"))
+    assert_fixed_point_precision {|n| sin(BigDecimal("1"), n) }
+    assert_fixed_point_precision {|n| sin(BigDecimal("1e-30"), n) }
+    assert_fixed_point_precision {|n| sin(BigDecimal(PI(50)), n) }
+    assert_fixed_point_precision {|n| sin(BigDecimal(PI(50) * 100), n) }
   end
 
   def test_cos
@@ -51,6 +83,12 @@ class TestBigMath < Test::Unit::TestCase
     assert_in_delta(-1.0, cos(PI(N) * 21, N))
     assert_in_delta(1.0, cos(PI(N) * 30, N))
     assert_in_delta(0.0, cos(PI(N) * BigDecimal("301.5"), N))
+    assert_in_delta(BigDecimal('0.5'), cos(PI(100) / 3, 100), BigDecimal("1e-100"))
+    assert_in_delta(SQRT3 / 2, cos(PI(100) / 6, 100), BigDecimal("1e-100"))
+    assert_in_delta(SQRT2 / 2, cos(PI(100) / 4, 100), BigDecimal("1e-100"))
+    assert_fixed_point_precision {|n| cos(BigDecimal("1"), n) }
+    assert_fixed_point_precision {|n| cos(BigDecimal(PI(50) / 2), n) }
+    assert_fixed_point_precision {|n| cos(BigDecimal(PI(50) * 201 / 2), n) }
   end
 
   def test_atan
@@ -58,13 +96,23 @@ class TestBigMath < Test::Unit::TestCase
     assert_in_delta(Math::PI/4, atan(BigDecimal("1.0"), N))
     assert_in_delta(Math::PI/6, atan(sqrt(BigDecimal("3.0"), N) / 3, N))
     assert_in_delta(Math::PI/2, atan(PINF, N))
+    assert_in_delta(PI(100) / 3, atan(SQRT3, 100), BigDecimal("1e-100"))
     assert_equal(BigDecimal("0.823840753418636291769355073102514088959345624027952954058347023122539489"),
                  atan(BigDecimal("1.08"), 72).round(72), '[ruby-dev:41257]')
+    assert_relative_precision {|n| atan(BigDecimal("2"), n)}
+    assert_relative_precision {|n| atan(BigDecimal("1e-30"), n)}
+    assert_relative_precision {|n| atan(BigDecimal("1e30"), n)}
   end
 
   def test_log
     assert_equal(0, BigMath.log(BigDecimal("1.0"), 10))
     assert_in_epsilon(Math.log(10)*1000, BigMath.log(BigDecimal("1e1000"), 10))
+    assert_in_epsilon(BigDecimal("2.3025850929940456840179914546843642076011014886287729760333279009675726096773524802359972050895982983419677840422862"),
+                      BigMath.log(BigDecimal("10"), 100), BigDecimal("1e-100"))
+    assert_relative_precision {|n| BigMath.log(BigDecimal("2"), n) }
+    assert_relative_precision {|n| BigMath.log(BigDecimal("1e-30") + 1, n) }
+    assert_relative_precision {|n| BigMath.log(BigDecimal("1e-30"), n) }
+    assert_relative_precision {|n| BigMath.log(BigDecimal("1e30"), n) }
     assert_raise(Math::DomainError) {BigMath.log(BigDecimal("0"), 10)}
     assert_raise(Math::DomainError) {BigMath.log(BigDecimal("-1"), 10)}
     assert_separately(%w[-rbigdecimal], <<-SRC)


### PR DESCRIPTION
Precision assertion in BigMath test is missing.
BigMath uses `BigDecimal.double_fig` (16 in my env), so the calculated precision is normally >=16.
We need to test with precision several times larger than 16 to ensure that the result is really precise enough.

This assertion will be helpful when adding new methods to BigMath (example: `BigMath.tan`)

## Precision check
Assume `BigMath.func(v, 2 * prec)` to be the expected result which is precise enough and calculates the difference.
`assert_fixed_point_precision` is for sin and cos. `assert_relative_precision` is for other methods.

## sin and cos

I think `BigMath.sin(x)`, `BigMath.cos(x)` with large `x` is not precise enough. This test case is not added in this pull request.
```ruby
BigMath.sin(BigDecimal('1e50'), 100) - BigMath.sin(BigDecimal('1e50'), 200)
# => -0.7388355386-67 # precision should be >=100 but is 67
```
