### PR TITLE
Remove outdated BigMath.atan document that referrs to convergence

### DIFF
--- a/lib/bigdecimal/math.rb
+++ b/lib/bigdecimal/math.rb
@@ -7,13 +7,12 @@ require 'bigdecimal'
 #   sqrt(x, prec)
 #   sin (x, prec)
 #   cos (x, prec)
-#   atan(x, prec)  Note: |x|<1, x=0.9999 may not converge.
+#   atan(x, prec)
 #   PI  (prec)
 #   E   (prec) == exp(1.0,prec)
 #
 # where:
 #   x    ... BigDecimal number to be computed.
-#            |x| must be small enough to get convergence.
 #   prec ... Number of digits to be obtained.
 #++
 #


### PR DESCRIPTION
These comments are outdated
```
Note: |x|<1, x=0.9999 may not converge.
|x| must be small enough to get convergence.
```

The restriction `|x|<1` is removed with https://github.com/ruby/bigdecimal/commit/b651cb3108f23c96b8959ec3d599eb4b27712be8
`x=0.9999 may not converge` is fixed with https://github.com/ruby/bigdecimal/commit/dfc51f2f80ce8ae5dd131a01aa5a79bbcec74d8c