### PR TITLE
Fix BigMath.atan precision safe margin

### DIFF
--- a/lib/bigdecimal/math.rb
+++ b/lib/bigdecimal/math.rb
@@ -149,9 +149,9 @@ module BigMath
     x = -x if neg = x < 0
     return pi.div(neg ? -2 : 2, prec) if x.infinite?
     return pi / (neg ? -4 : 4) if x.round(prec) == 1
-    x = BigDecimal("1").div(x, prec) if inv = x > 1
-    x = (-1 + sqrt(1 + x**2, prec))/x if dbl = x > 0.5
-    n    = prec + BigDecimal.double_fig
+    n = prec + BigDecimal.double_fig
+    x = BigDecimal("1").div(x, n) if inv = x > 1
+    x = (-1 + sqrt(1 + x.mult(x, n), n)).div(x, n) if dbl = x > 0.5
     y = x
     d = y
     t = x


### PR DESCRIPTION
Increase `BigMath.atan(x, prec)` precision when `|x|>0.5`
    
`BigMath.atan(x, prec)` is calculated with `precision=prec+BigDecimal.double_fig` `when |x| <= 0.5`.
But this safe margin was not properly applied when `|x| > 0.5`.

```ruby
BigMath.atan(BigDecimal('0.2'), 100) #=> accuracy was about 116 digits
BigMath.atan(BigDecimal('0.8'), 100) #=> accuracy was about 108 digits
BigMath.atan(BigDecimal('3'), 100) #=> accuracy was about 100 digits
```
