### PR TITLE
Implement BigMath.tan

### DIFF
--- a/test/bigdecimal/test_bigmath.rb
+++ b/test/bigdecimal/test_bigmath.rb
@@ -80,6 +80,28 @@ class TestBigMath < Test::Unit::TestCase
     assert_operator(cos(PI(30) * 2, 30), :<=, 1)
   end
 
+  def test_tan
+    assert_in_delta(0.0, tan(-PI(N), N))
+    assert_in_delta(0.0, tan(BigDecimal(0), N))
+    assert_in_delta(0.0, tan(PI(N), N))
+    assert_in_delta(1.0, tan(PI(N) / 4, N))
+    assert_in_delta(-1.0, tan(-PI(N) / 4, N))
+    assert_in_delta(-1.0, tan(PI(N) * 3 / 4, N))
+    assert_in_delta(1.0, tan(-PI(N) * 3 / 4, N))
+    assert_in_delta(0.0, tan(PI(N) * 100, N))
+    assert_in_delta(1.0, tan(PI(N) * 101 / 4, N))
+    assert_in_delta(-1.0, tan(PI(N) * 103 / 4, N))
+    assert_in_delta(BigDecimal("1").div(SQRT3, 100), tan(PI(100) / 6, 100), BigDecimal("1e-100"))
+    assert_in_delta(SQRT3, tan(PI(100) / 3, 100), BigDecimal("1e-100"))
+    assert_relative_precision {|n| tan(BigDecimal("0.5"), n) }
+    assert_relative_precision {|n| tan(BigDecimal("1e-30"), n) }
+    assert_relative_precision {|n| tan(BigDecimal("1.5"), n) }
+    assert_relative_precision {|n| tan(PI(100) / 2, n) }
+    assert_relative_precision {|n| tan(PI(200) * 101 / 2, n) }
+    assert_relative_precision {|n| tan(PI(100), n) }
+    assert_relative_precision {|n| tan(PI(200) * 100, n) }
+  end
+
   def test_atan
     assert_equal(0.0, atan(BigDecimal("0.0"), N))
     assert_in_delta(Math::PI/4, atan(BigDecimal("1.0"), N))


### PR DESCRIPTION
#81

Calculate `tan(x, prec)` by `sin(x, sin_prec) / cos(x, cos_prec)`.
If the precision of sin/cos is not enough, increase prec and recalculate again.

### Example of increasing precision of cosine
```ruby
x = BigMath::PI(150) / 2
BigMath.tan(x, 100)

# First, calculate cos with denominator_prec = 116
cos(x, 116) #=> -0.57442751e-131
# This value is not correct at all. We can only know that |cos(x, 116)| < 1e-116.
# No information to estimate appropriate denominator_prec, so multiply denominator_prec by 3/2 and recalculate

116 * 3 / 2 #=> 174
cos(x, 174) #=> -0.133945260097112077688525522e-165

# This value is inaccurate. Only the first 174-165 = 9 digits can be trusted.
# We need at least 91 more digits, so increase denominator_prec by 91+double_fig and recalculate

174 + 91 + 16 #=> 281
cos(x, 281) #=> -0.133945260097112077688525577-165

# Now precision of cos is enough to calculate sin(x)/cos(x)
return sin(x, 100) / cos(x, 281) #=> -0.7465736370775545e166
```


### About sin and cos precision
```ruby
BigMath.sin(around_zero, prec)
#=> relative precision. `(calculated_value/true_value - 1).abs < 10**(-prec)` seems to be ensured

BigMath.sin(other_value, prec)
#=> fixed point precision. `(calculated_value - true_value).abs < 10**(-prec)` is ensured

BigMath.cos(other_value, prec)
#=> fixed point precision. `(calculated_value - true_value).abs < 10**(-prec)` is ensured
```
