### PR TITLE
Simplify power by integer logic

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -7655,7 +7655,7 @@ Exit:
 VP_EXPORT int
 VpPowerByInt(Real *y, Real *x, SIGNED_VALUE n)
 {
-    size_t s, ss;
+    size_t s;
     ssize_t sign;
     Real *w1 = NULL;
     Real *w2 = NULL;
@@ -7721,17 +7721,20 @@ VpPowerByInt(Real *y, Real *x, SIGNED_VALUE n)
     /* calculation start */
 
     VpAsgn(y, x, 1);
+    VpAsgn(w1, x, 1);
     --n;
-    while (n > 0) {
-	VpAsgn(w1, x, 1);
-	s = 1;
-	while (ss = s, (s += s) <= (size_t)n) {
+    s = 1;
+
+    while (s <= (size_t)n) {
+	if (s != 1) {
 	    VpMult(w2, w1, w1);
 	    VpAsgn(w1, w2, 1);
 	}
-	n -= (SIGNED_VALUE)ss;
-	VpMult(w2, y, w1);
-	VpAsgn(y, w2, 1);
+	if (s & n) {
+	    VpMult(w2, y, w1);
+	    VpAsgn(y, w2, 1);
+	}
+	s <<= 1;
     }
     if (sign < 0) {
 	VpDivd(w1, w2, VpConstOne, y);

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1660,8 +1660,7 @@ class TestBigDecimal < Test::Unit::TestCase
     BigDecimal.save_limit do
       BigDecimal.limit(1)
       x = BigDecimal("3")
-      assert_equal(90, x ** 4) # OK? must it be 80?
-      # 3 * 3 * 3 * 3 = 10 * 3 * 3 = 30 * 3 = 90 ???
+      assert_equal(80, x ** 4)
       assert_raise(ArgumentError) { BigDecimal.limit(-1) }
 
       bug7458 = '[ruby-core:50269] [#7458]'


### PR DESCRIPTION
Refactor and reduce the number of multiplication.

Example calculation of `x**16`
```ruby
x * x**8 * x**4 * x**2 * x # x**8, x**4, x**2 are calculate separately
# ↓
x * x * x**2 * x**4 * x**8 # result of x**4 is re-used to calculate x**8
```

Calculation of the largest `x**n` is dominant. Although multiplication is reduced, the performance improvement is limited.
