### PR TITLE
Implement BigDecimal#_decimal_shift for internal use

### DIFF
--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1490,6 +1490,23 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_in_delta(BigDecimal('0.' + '0' * 25 + '3' * 100), x.sqrt(1), BigDecimal('1e-125'))
   end
 
+  def test_internal_use_decimal_shift
+    assert_positive_infinite_calculation { BigDecimal::INFINITY._decimal_shift(10) }
+    assert_negative_infinite_calculation { NEGATIVE_INFINITY._decimal_shift(10) }
+    assert_nan_calculation { BigDecimal::NAN._decimal_shift(10) }
+    assert_equal(BigDecimal(0), BigDecimal(0)._decimal_shift(10))
+    [
+      BigDecimal('-1234.56789'),
+      BigDecimal('123456789.012345678987654321'),
+      BigDecimal('123456789012345.678987654321')
+    ].each do |num|
+      (0..20).each do |shift|
+        assert_equal(num * 10**shift, num._decimal_shift(shift))
+        assert_equal(num / 10**shift, num._decimal_shift(-shift))
+      end
+    end
+  end
+
   def test_fix
     x = BigDecimal("1.1")
     assert_equal(1, x.fix)


### PR DESCRIPTION
Introduce `BigDecimal#_decimal_shift(n)` for internal use.
`BigMath.exp` and `BigMath.log ` now uses it instead of `x * BigDecimal("1e#{shift}")`
```diff
- x = x * BigDecimal("1e#{-exponent}")
+ x = x._decimal_shift(-exponent)
```

```ruby
irb(main):002> x = BigDecimal('1'*10000)
irb(main):003> 10000.times{x*10}
# processing time: 0.064433s
=> 10000
irb(main):004> 10000.times{x._decimal_shift 1}
# processing time: 0.041025s
=> 10000
irb(main):005> 10000.times{x/10}
# processing time: 0.287047s
=> 10000
irb(main):006> 10000.times{x._decimal_shift -1}
# processing time: 0.022237s
=> 10000
```
