### PR TITLE
Allocate minimum necessary digits for quotient and remainder

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2219,9 +2219,9 @@ BigDecimal_div2(VALUE self, VALUE b, VALUE n)
             b_prec = BIGDECIMAL_DOUBLE_FIGURES;
         }
         GUARD_OBJ(bv, GetVpValueWithPrec(b, b_prec, 1));
-        mx = av->Prec + bv->Prec + 2;
-        if (mx <= cv->MaxPrec) mx = cv->MaxPrec + 1;
-        GUARD_OBJ(res, NewZeroWrapNolimit(1, (mx * 2  + 2)*VpBaseFig()));
+        mx = bv->Prec + cv->MaxPrec - 1;
+        if (mx <= av->Prec) mx = av->Prec + 1;
+        GUARD_OBJ(res, NewZeroWrapNolimit(1, mx * VpBaseFig()));
         VpDivd(cv, res, av, bv);
         VpSetPrecLimit(pl);
         VpLeftRound(cv, VpGetRoundMode(), ix);

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -982,7 +982,7 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_div_gh220
     x = BigDecimal("1.0")
     y = BigDecimal("3672577333.6608990499165058135986328125")
-    c = BigDecimal("0.272288343892592687909520102748926752911779209181321744700032723729015151607289998e-9")
+    c = BigDecimal("0.272288343892592687909520102748926752911779209181321745e-9")
     assert_equal(c, x / y, "[GH-220]")
   end
 
@@ -993,6 +993,22 @@ class TestBigDecimal < Test::Unit::TestCase
     c = a/b
     assert(c.precision > b.precision,
            "(101/0.9163472602589686).precision >= (0.9163472602589686).precision #{bug13754}")
+  end
+
+  def test_div_various_precisions
+    a_precs = [5, 20, 70]
+    b_precs = [*5..80]
+    exponents = [0, 5]
+    a_precs.product(exponents, b_precs, exponents).each do |prec_a, ex_a, prec_b, ex_b|
+      a = BigDecimal('7.' + '1' * (prec_a - 1) + "e#{ex_a}")
+      b = BigDecimal('3.' + '1' * (prec_b - 1) + "e#{ex_b}")
+      c = a / b
+      max = [prec_a, prec_b, BigDecimal.double_fig].max
+      # Precision must be enough and not too large
+      precision_min = max + BigDecimal.double_fig / 2
+      precision_max = max + 2 * BigDecimal.double_fig
+      assert_includes(precision_min..precision_max, c.n_significant_digits)
+    end
   end
 
   def test_div_with_float

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1011,6 +1011,20 @@ class TestBigDecimal < Test::Unit::TestCase
     end
   end
 
+  def test_div2_various_precisions
+    a_precs = [5, 20, 70, 100]
+    b_precs = [5, 20, 70, 100]
+    c_precs = [5, 20, 30, 70, 100, 200]
+    exponents = [0, 5]
+    a_precs.product(exponents, b_precs, exponents, c_precs).each do |prec_a, ex_a, prec_b, ex_b, prec_c|
+      a = BigDecimal('7.' + '1' * (prec_a - 1) + "e#{ex_a}")
+      b = BigDecimal('3.' + '1' * (prec_b - 1) + "e#{ex_b}")
+      c = a.div(b, prec_c)
+      assert_in_delta(prec_c, c.n_significant_digits, 2)
+      assert_in_delta(a, c * b, a * 10**(1 - prec_c))
+    end
+  end
+
   def test_div_with_float
     assert_kind_of(BigDecimal, BigDecimal("3") / 1.5)
     assert_equal(BigDecimal("0.5"), BigDecimal(1) / 2.0)


### PR DESCRIPTION
Fixes #220 and #222
Fixes wrong calculation of quotient and remainder precision in `a / b` division.

Precision of quotient is sufficient enough with `[a_prec,b_prec].max+extra`.
Required remainder allocation size can be calculated from requirements of VpDivd.
VpDivd requires `r_maxprec > a_prec` and `r_maxprec > b_prec+c_maxprec-2`.
