### PR TITLE
Use `Ractor#value` as `Ractor#take` is removed

### DIFF
--- a/test/bigdecimal/test_ractor.rb
+++ b/test/bigdecimal/test_ractor.rb
@@ -13,11 +13,15 @@ class TestBigDecimalRactor < Test::Unit::TestCase
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
       $VERBOSE = nil
+      class Ractor
+        alias value take unless method_defined? :value
+      end
+
       require "bigdecimal"
       r = Ractor.new BigDecimal(Math::PI, Float::DIG+1) do |pi|
         BigDecimal('2.0')*pi
       end
-      assert_equal(2*Math::PI, r.take)
+      assert_equal(2*Math::PI, r.value)
     end;
   end
 end


### PR DESCRIPTION
To keep compatibility with older Rubys, left alias value take.

See https://bugs.ruby-lang.org/issues/21262
