### PR TITLE
Apply preclimit in BigDecimal_div2 when specified prec is 0

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2151,6 +2151,7 @@ BigDecimal_div2(VALUE self, VALUE b, VALUE n)
     ix = check_int_precision(n);
 
     pl = VpSetPrecLimit(0);
+    if (ix == 0) ix = pl;
 
     GUARD_OBJ(av, GetVpValue(self, 1));
     if (RB_FLOAT_TYPE_P(b) && ix > BIGDECIMAL_DOUBLE_FIGURES) {

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1725,6 +1725,24 @@ class TestBigDecimal < Test::Unit::TestCase
     end
   end
 
+  def test_arithmetic_operation_with_limit
+    BigDecimal.save_limit do
+      BigDecimal.limit(3)
+      assert_equal(BigDecimal('0.889'), (BigDecimal('0.8888') + BigDecimal('0')))
+      assert_equal(BigDecimal('0.889'), (BigDecimal('0.8888') - BigDecimal('0')))
+      assert_equal(BigDecimal('2.66'), (BigDecimal('0.888') * BigDecimal('3')))
+      assert_equal(BigDecimal('0.296'), (BigDecimal('0.8888') / BigDecimal('3')))
+      assert_equal(BigDecimal('0.889'), BigDecimal('0.8888').add(BigDecimal('0'), 0))
+      assert_equal(BigDecimal('0.889'), BigDecimal('0.8888').sub(BigDecimal('0'), 0))
+      assert_equal(BigDecimal('2.66'), BigDecimal('0.888').mult(BigDecimal('3'), 0))
+      assert_equal(BigDecimal('0.296'), BigDecimal('0.8888').div(BigDecimal('3'), 0))
+      assert_equal(BigDecimal('0.8888'), BigDecimal('0.8888').add(BigDecimal('0'), 5))
+      assert_equal(BigDecimal('0.8888'), BigDecimal('0.8888').sub(BigDecimal('0'), 5))
+      assert_equal(BigDecimal('2.664'), BigDecimal('0.888').mult(BigDecimal('3'), 5))
+      assert_equal(BigDecimal('0.29627'), BigDecimal('0.8888').div(BigDecimal('3'), 5))
+    end
+  end
+
   def test_sign
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)


### PR DESCRIPTION
Preclimit in `BigDecimal#/` and `BigDecimal#div` was accidentally dropped in #329

Some test in ruby/spec is failing. https://github.com/ruby/spec/blob/master/library/bigdecimal/limit_spec.rb