### PR TITLE
Make precision calculation in bigdecimal.div(value, 0) gc-compaction safe

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -513,15 +513,10 @@ BigDecimal_prec(VALUE self)
 }
 
 static void
-BigDecimal_count_precision_and_scale(VALUE self, ssize_t *out_precision, ssize_t *out_scale)
+VpCountPrecisionAndScale(Real *p, ssize_t *out_precision, ssize_t *out_scale)
 {
-    ENTER(1);
-
     if (out_precision == NULL && out_scale == NULL)
         return;
-
-    Real *p;
-    GUARD_OBJ(p, GetVpValue(self, 1));
     if (VpIsZero(p) || !VpIsDef(p)) {
       zero:
         if (out_precision) *out_precision = 0;
@@ -623,6 +618,15 @@ BigDecimal_count_precision_and_scale(VALUE self, ssize_t *out_precision, ssize_t
 
         *out_scale = scale;
     }
+}
+
+static void
+BigDecimal_count_precision_and_scale(VALUE self, ssize_t *out_precision, ssize_t *out_scale)
+{
+    ENTER(1);
+    Real *p;
+    GUARD_OBJ(p, GetVpValue(self, 1));
+    VpCountPrecisionAndScale(p, out_precision, out_scale);
 }
 
 /*
@@ -2166,8 +2170,8 @@ BigDecimal_div2(VALUE self, VALUE b, VALUE n)
 
     if (ix == 0) {
         ssize_t a_prec, b_prec;
-        BigDecimal_count_precision_and_scale(av->obj, &a_prec, NULL);
-        BigDecimal_count_precision_and_scale(bv->obj, &b_prec, NULL);
+        VpCountPrecisionAndScale(av, &a_prec, NULL);
+        VpCountPrecisionAndScale(bv, &b_prec, NULL);
         ix = ((a_prec > b_prec) ? a_prec : b_prec) + BIGDECIMAL_DOUBLE_FIGURES;
         if (2 * BIGDECIMAL_DOUBLE_FIGURES > ix)
             ix = 2 * BIGDECIMAL_DOUBLE_FIGURES;

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -2340,6 +2340,53 @@ class TestBigDecimal < Test::Unit::TestCase
     }
   end
 
+  def test_gc_compaction_safe
+    omit if RUBY_VERSION < "3.2" || RUBY_ENGINE == "truffleruby"
+
+    assert_separately(["-rbigdecimal"], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      x = 1.5
+      y = 0.5
+      nan = BigDecimal("NaN")
+      inf = BigDecimal("Infinity")
+      bx = BigDecimal(x.to_s)
+      by = BigDecimal(y.to_s)
+      GC.verify_compaction_references(expand_heap: true, toward: :empty)
+
+      assert_in_delta(x + y, bx + by)
+      assert_in_delta(x + y, bx.add(by, 10))
+      assert_in_delta(x - y, bx - by)
+      assert_in_delta(x - y, bx.sub(by, 10))
+      assert_in_delta(x * y, bx * by)
+      assert_in_delta(x * y, bx.mult(by, 10))
+      assert_in_delta(x / y, bx / by)
+      assert_in_delta(x / y, bx.div(by, 10))
+      assert_in_delta((x / y).floor, bx.div(by))
+      assert_in_delta(x % y, bx % by)
+      assert_in_delta(Math.sqrt(x), bx.sqrt(10))
+      assert_equal(x.div(y), bx.div(by))
+      assert_equal(x.remainder(y), bx.remainder(by))
+      assert_equal(x.divmod(y), bx.divmod(by))
+      # assert_equal([0, x], bx.divmod(inf))
+      # assert_in_delta(x, bx.remainder(inf))
+      # assert((nan + nan).nan?)
+      # assert((nan - nan).nan?)
+      assert((nan * nan).nan?)
+      assert((nan / nan).nan?)
+      assert((nan % nan).nan?)
+      assert((inf + inf).infinite?)
+      assert((inf - inf).nan?)
+      assert((inf * inf).infinite?)
+      assert((inf / inf).nan?)
+      assert((inf % inf).nan?)
+      # assert_in_delta(Math.exp(x), BigMath.exp(bx, 10))
+      # assert_in_delta(x**y, bx**by)
+      # assert_in_delta(x**y, bx.power(by, 10))
+      # assert_in_delta(Math.exp(x), BigMath.exp(bx, 10))
+      # assert_in_delta(Math.log(x), BigMath.log(bx, 10))
+    end;
+  end
+
   def assert_no_memory_leak(code, *rest, **opt)
     code = "8.times {20_000.times {begin #{code}; rescue NoMemoryError; end}; GC.start}"
     paths = $LOAD_PATH.map{|path| "-I#{path}" }


### PR DESCRIPTION
Fix #337

((Real*)x)->obj, a reference from T_DATA to VALUE, will be garbled after gc compaction. We should avoid using x->obj as possible for now. It should be removed from struct Real in the future.
