### PR TITLE
Fix sign of bigdecimal**bigint

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -3155,15 +3155,15 @@ BigDecimal_power(int argc, VALUE*argv, VALUE self)
     else if (RB_TYPE_P(vexp, T_BIGNUM)) {
         VALUE abs_value = BigDecimal_abs(self);
         if (is_one(abs_value)) {
-            return VpCheckGetValue(NewOneWrapLimited(1, n));
+            return VpCheckGetValue(NewOneWrapLimited(is_even(vexp) ? 1 : VpGetSign(x), n));
         }
         else if (RTEST(rb_funcall(abs_value, '<', 1, INT2FIX(1)))) {
             if (is_negative(vexp)) {
                 y = NewZeroWrapLimited(1, n);
-                VpSetInf(y, (is_even(vexp) ? 1 : -1) * VpGetSign(x));
+                VpSetInf(y, is_even(vexp) ? 1 : VpGetSign(x));
                 return VpCheckGetValue(y);
             }
-            else if (BIGDECIMAL_NEGATIVE_P(x) && is_even(vexp)) {
+            else if (BIGDECIMAL_NEGATIVE_P(x) && !is_even(vexp)) {
                 return VpCheckGetValue(NewZeroWrapLimited(-1, n));
             }
             else {
@@ -3173,10 +3173,10 @@ BigDecimal_power(int argc, VALUE*argv, VALUE self)
         else {
             if (is_positive(vexp)) {
                 y = NewZeroWrapLimited(1, n);
-                VpSetInf(y, (is_even(vexp) ? 1 : -1) * VpGetSign(x));
+                VpSetInf(y, is_even(vexp) ? 1 : VpGetSign(x));
                 return VpCheckGetValue(y);
             }
-            else if (BIGDECIMAL_NEGATIVE_P(x) && is_even(vexp)) {
+            else if (BIGDECIMAL_NEGATIVE_P(x) && !is_even(vexp)) {
                 return VpCheckGetValue(NewZeroWrapLimited(-1, n));
             }
             else {

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1534,22 +1534,25 @@ class TestBigDecimal < Test::Unit::TestCase
       assert_negative_infinite((-BigDecimal(0)) ** -(2**100 + 1))
 
       assert_equal(1, BigDecimal(1) ** (2**100))
+      assert_equal(1, BigDecimal(-1) ** (2**100))
+      assert_equal(1, BigDecimal(1) ** (2**100 + 1))
+      assert_equal(-1, BigDecimal(-1) ** (2**100 + 1))
 
       assert_positive_infinite(BigDecimal(3) ** (2**100))
       assert_positive_zero(BigDecimal(3) ** (-2**100))
 
-      assert_negative_infinite(BigDecimal(-3) ** (2**100))
-      assert_positive_infinite(BigDecimal(-3) ** (2**100 + 1))
-      assert_negative_zero(BigDecimal(-3) ** (-2**100))
-      assert_positive_zero(BigDecimal(-3) ** (-2**100 - 1))
+      assert_positive_infinite(BigDecimal(-3) ** (2**100))
+      assert_negative_infinite(BigDecimal(-3) ** (2**100 + 1))
+      assert_positive_zero(BigDecimal(-3) ** (-2**100))
+      assert_negative_zero(BigDecimal(-3) ** (-2**100 - 1))
 
       assert_positive_zero(BigDecimal(0.5, Float::DIG) ** (2**100))
       assert_positive_infinite(BigDecimal(0.5, Float::DIG) ** (-2**100))
 
-      assert_negative_zero(BigDecimal(-0.5, Float::DIG) ** (2**100))
-      assert_positive_zero(BigDecimal(-0.5, Float::DIG) ** (2**100 - 1))
-      assert_negative_infinite(BigDecimal(-0.5, Float::DIG) ** (-2**100))
-      assert_positive_infinite(BigDecimal(-0.5, Float::DIG) ** (-2**100 - 1))
+      assert_positive_zero(BigDecimal(-0.5, Float::DIG) ** (2**100))
+      assert_negative_zero(BigDecimal(-0.5, Float::DIG) ** (2**100 - 1))
+      assert_positive_infinite(BigDecimal(-0.5, Float::DIG) ** (-2**100))
+      assert_negative_infinite(BigDecimal(-0.5, Float::DIG) ** (-2**100 - 1))
     end
   end
 


### PR DESCRIPTION
Sign of `bigdecimal**bigint` was wrong.

```ruby
(-1)**(2**50)       # => 1
(-1)**(2**50 + 1)   # => -1

(-3.0)**(2**50)     # => Infinity
(-3.0)**(2**50 + 1) # => -Infinity

(-0.5)**(2**50)     # => 0.0
(-0.5)**(2**50 + 1) # => -0.0


BigDecimal(-1)**(2**200)         # => 0.1e1
BigDecimal(-1)**(2**200 + 1)     # => 0.1e1 → -0.1e1

BigDecimal(-3)**(2**200)         # -Infinity → Infinity
BigDecimal(-3)**(2**200 + 1)     # Infinity  → -Infinity

BigDecimal('-0.5')**(2**200)     # => -0.0 → 0.0
BigDecimal('-0.5')**(2**200 + 1) # => 0.0  → -0.0
```
