### PR TITLE
Fix precision of bigdecimal.power(integer, prec)

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -3176,7 +3176,7 @@ BigDecimal_power(int argc, VALUE*argv, VALUE self)
     }
     VpPowerByInt(y.real, x.real, int_exp);
     if (!NIL_P(prec) && VpIsDef(y.real)) {
-        VpMidRound(y.real, VpGetRoundMode(), n);
+        VpMidRound(y.real, VpGetRoundMode(), n - VpExponent10(y.real));
     }
     return CheckGetValue(y);
 }

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1709,7 +1709,10 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(pow, pi.power(e, 20))
 
     b = BigDecimal('1.034482758620689655172413793103448275862068965517241379310344827586206896551724')
-    assert_equal(BigDecimal('0.114523E1'), b.power(4, 5), '[Bug #8818] [ruby-core:56802]')
+    assert_equal(BigDecimal('0.11452E1'), b.power(4, 5), '[Bug #8818] [ruby-core:56802]')
+
+    assert_equal(BigDecimal('0.537676775108E-7'), BigDecimal('0.1234').power(8, 12))
+    assert_equal(BigDecimal('0.537676775108E9'), BigDecimal('12.34').power(8, 12))
   end
 
   def test_limit


### PR DESCRIPTION
Fixes #352

Fixes this lack of precision bug
```ruby
BigDecimal('0.1234').power(8, 12) #=> 0.53768e-7
BigDecimal('12.34').power(-8, 12) #=> 0.186e-8
```

```ruby
BigDecimal('0.1234').power(8, 12)
# before: 0.53768e-7
# after:  0.537676775108e-7

BigDecimal('12.34').power(-8, 12)
# before: 0.186e-8
# after:  0.185985344038e-8
```

Too high precision gets lower in some case

```ruby
BigDecimal('12.34').power(8.000000000001, 12)
# =>      0.537676775109e9 (doesn't change in this pull request)

BigDecimal('12.34').power(8, 12)
# before: 0.537676775108238564041e9 (precision too high)
# after:  0.537676775108e9 (precision consistent with power by non-integer)
```