### PR TITLE
Improve sqrt calculation

### DIFF
--- a/test/bigdecimal/test_bigmath.rb
+++ b/test/bigdecimal/test_bigmath.rb
@@ -29,8 +29,12 @@ class TestBigMath < Test::Unit::TestCase
     assert_in_delta(SQRT2, sqrt(BigDecimal("2"), 100), BigDecimal("1e-100"))
     assert_in_delta(SQRT3, sqrt(BigDecimal("3"), 100), BigDecimal("1e-100"))
     assert_relative_precision {|n| sqrt(BigDecimal("2"), n) }
+    assert_relative_precision {|n| sqrt(BigDecimal("1.01"), n) }
+    assert_relative_precision {|n| sqrt(BigDecimal("0.99"), n) }
     assert_relative_precision {|n| sqrt(BigDecimal("2e-50"), n) }
     assert_relative_precision {|n| sqrt(BigDecimal("2e50"), n) }
+    assert_relative_precision {|n| sqrt(1 - BigDecimal("1e-30"), n) }
+    assert_relative_precision {|n| sqrt(1 + BigDecimal("1e-30"), n) }
   end
 
   def test_sin


### PR DESCRIPTION
There are two pull request with different approach to improve sqrt performance.
This one improves existing C-implemented newton's method.
Another one #319 is to use implement it in Ruby using `Integer.sqrt`.

Reduce iteration count of Newton's method

Speeds up in every scenario
```ruby
# SQRT2
two = BigDecimal(2);

10000.times { two.sqrt(10) }
# processing time: 0.119187s → 0.015462s

10000.times { two.sqrt(32) }
# processing time: 0.026030s → 0.022965s

10000.times { two.sqrt(100) }
# processing time: 0.046182s → 0.029414s

10000.times { two.sqrt(1000) }
# processing time: 2.851953s → 0.623147s

two.sqrt(10000)
# processing time: 0.379927s → 0.018168s

# Fast path
BigDecimal(121).sqrt(10000)
# processing time: 0.020247s → 0.000196s

# Many digits
BigDecimal(2).div(7, 10000).sqrt(10000)
# processing time: 1.004524s → 0.017824s
# note: using Integer.sqrt is faster(0.002656s) in this case
```
