### PR TITLE
Remove BigDecimal_divremain(which has a bug) and use BigDecimal_DoDivmod instead

### DIFF
--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1079,6 +1079,7 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(-1, (-x).remainder(3))
     assert_equal(1, x.remainder(-3))
     assert_equal(-1, (-x).remainder(-3))
+    assert_equal(BigDecimal("1e-10"), BigDecimal("1e10").remainder(BigDecimal("3e-10")))
   end
 
   def test_remainder_with_float
@@ -1091,7 +1092,7 @@ class TestBigDecimal < Test::Unit::TestCase
 
   def test_remainder_coerce
     o = Object.new
-    def o.coerce(x); [x, BigDecimal("3")]; end
+    def o.coerce(x); [x, BigDecimal("-3")]; end
     assert_equal(BigDecimal("1.1"), BigDecimal("7.1").remainder(o))
   end
 


### PR DESCRIPTION
Fixes #350
BigDecimal_divremain has a bug.
The expected divremain implementation is identical to  BigDecimal_DoDivmod except `/* result adjustment for negative case */` part.
We should use the same logic instead of fixing BigDecimal_divremain by copy-paste.

Fixes
```ruby
# Precision of internal division was wrong
BigDecimal(1).remainder(BigDecimal("3e-100"))
#=> 0.1e0 → 0.1e-99

# Precision of internal division was depending on internal MaxPrec
(BigDecimal(1)**2).remainder(BigDecimal('3e-100'))
#=> 0.1e-27 → 0.1e-99
(BigDecimal(1)**5).remainder(BigDecimal('3e-100'))
#=> 0.1e-54 → 0.1e-99
```
