### PR TITLE
Fix wrong converge check in VpSqrt

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -7261,7 +7261,7 @@ VpSqrt(Real *y, Real *x)
         VpDivd(f, r, x, y);        /* f = x/y    */
         VpAddSub(r, f, y, -1);     /* r = f - y  */
         VpMult(f, VpConstPt5, r);  /* f = 0.5*r  */
-        if (VpIsZero(f))
+        if (y_prec == y->MaxPrec && VpIsZero(f))
             goto converge;
         VpAddSub(r, f, y, 1);      /* r = y + f  */
         VpAsgn(y, r, 1);           /* y = r      */

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1225,6 +1225,8 @@ class TestBigDecimal < Test::Unit::TestCase
     x = BigDecimal((2**200).to_s)
     assert_equal(2**100, x.sqrt(1))
 
+    assert_in_delta(BigDecimal("4.0000000000000000000125"), BigDecimal("16.0000000000000000001").sqrt(100), BigDecimal("1e-40"))
+
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
     assert_raise_with_message(FloatDomainError, "sqrt of 'NaN'(Not a Number)") { BigDecimal("NaN").sqrt(1) }


### PR DESCRIPTION
Fix #338

`x/y == y` does not mean y converged to `sqrt(x)` if the precision of `x/y` is not high enough.
Perhaps there is a more complicated way to fix this convergence check, but #323  or #343 is better than doing it.
