### PR TITLE
Fix to_f underflow check when DECDIG is uint16_t

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -1353,7 +1353,7 @@ BigDecimal_to_f(VALUE self)
 	return rb_float_new(d);
     if (e > (SIGNED_VALUE)(DBL_MAX_10_EXP+BASE_FIG))
 	goto overflow;
-    if (e < (SIGNED_VALUE)(DBL_MIN_10_EXP-BASE_FIG))
+    if (e < (SIGNED_VALUE)(DBL_MIN_10_EXP-DBL_DIG))
 	goto underflow;
 
     str = rb_str_new(0, VpNumOfChars(v.real, "E"));


### PR DESCRIPTION
Fixes #202
(Some test already passes now, some test that still fail seems not a bug or a bug also in DECDIG=uint32_t)

```c
if (VpVtoD(&d, &e, v.real) != 1)
    return rb_float_new(d);
// Range of d is: 10**-BASE_FIG <= d < 1.0

// Overflow if d*10**e > 10**DBL_MAX_10_EXP = 1e+308
if (e > (SIGNED_VALUE)(DBL_MAX_10_EXP+BASE_FIG))
    goto overflow;
// Overflow if d*10**e < 10**(DBL_MAX_10_EXP - DBL_DIG) = 1e-323
if (e < (SIGNED_VALUE)(DBL_MIN_10_EXP-DBL_DIG))
    goto underflow;  
```

When DECDIG is `uint32_t`, `e` is a multiple of 9. (example: -315, -324)
In this case, result of wrong calculation `(e < (SIGNED_VALUE)(DBL_MIN_10_EXP-9))` and correct calculation `(e < (SIGNED_VALUE)(DBL_MIN_10_EXP-15))` was the same just by chance.