### PR TITLE
Fix VpNumOfChars calculation for the longest case

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -5028,7 +5028,7 @@ VpNumOfChars(Real *vp,const char *pszFmt)
       case 'E':
 	/* fall through */
       default:
-	nc = BASE_FIG*(vp->Prec + 2)+6; /* 3: sign + exponent chars */
+	nc = BASE_FIG * vp->Prec + 25; /* "-0."(3) + digits_chars + "e-"(2) + 64bit_exponent_chars(19) + null(1) */
     }
     return nc;
 }

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1503,6 +1503,9 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal("0.123456789012e0", BigDecimal("0.123456789012").inspect)
     assert_equal("0.123456789012e4", BigDecimal("1234.56789012").inspect)
     assert_equal("0.123456789012e-4", BigDecimal("0.0000123456789012").inspect)
+    s = '-0.123456789e-1000000000000000008'
+    x = BigDecimal(s)
+    assert_equal(s, x.inspect) unless x.infinite?
   end
 
   def test_power


### PR DESCRIPTION
Fix this bug
```ruby
x = BigDecimal('-0.123456789e-1000000000000000008')
x.exponent
#=> -1000000000000000008

x.to_s
# => "-0.123456789e-100000000000000000" (master branch)
# => "-0.123456789e-1000000000000000008" (this pull request)
```
