### PR TITLE
Use minimum necessary division precision in BigDecimal_DoDivmod

### DIFF
--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1107,6 +1107,14 @@ class TestBigDecimal < Test::Unit::TestCase
     end
   end
 
+  def test_div_round_worst_precision_case
+    x = BigDecimal(5)
+    y = BigDecimal(9 * BASE / 10)
+    (BASE_FIG * 2..BASE_FIG * 4).each do |prec|
+      assert_equal(BigDecimal('0.' + '5' * (prec - 1) + "6E-#{BASE_FIG - 1}"), x.div(y, prec))
+    end
+  end
+
   def test_div_rounding_with_small_remainder
     BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_HALF_UP)
     assert_equal(BigDecimal('0.12e1'), BigDecimal('1.25').div(BigDecimal("1.#{'0' * 30}1"), 2))
@@ -1209,6 +1217,28 @@ class TestBigDecimal < Test::Unit::TestCase
     b = BigDecimal('-1.23456789e10')
     q, r = a.divmod(b)
     assert_equal((a/b).round(0, :down) - 1, q)
+    assert_equal((a - q*b), r)
+
+    a = BigDecimal('3e100')
+    b = BigDecimal('-1.7e-100')
+    q, r = a.divmod(b)
+    assert_include(0...-b, -r)
+    assert_equal((a - q*b), r)
+
+    a = BigDecimal('0.32e23')
+    b = BigDecimal('-0.1999999999e-23')
+    q, r = a.divmod(b)
+    assert_include(0...-b, -r)
+    assert_equal((a - q*b), r)
+
+    a = BigDecimal('199.9999999999999999999999999')
+    q, r = a.divmod(1)
+    assert_equal([199, a - 199], [q, r])
+
+    a = BigDecimal('0.30000000000000000000000000000000000000000000000000000000000000001e91')
+    b = BigDecimal('0.1e20')
+    q, r = a.divmod(b)
+    assert_include(0...b, r)
     assert_equal((a - q*b), r)
   end
 


### PR DESCRIPTION
Improve performance of `div` and `divmod` in some case.
```ruby
BigDecimal('7'*100000).div(BigDecimal('3'*99999)) #=> 23
# processing time: 0.566657s → 0.001474s
```
In the above example, `div` needs to calculate division with 2-digits precision. But it was internally calculating with 200000-digits precision.


This pull request also fixes the cause of this bug (found while adding test)
```
BigDecimal('3e20').div(BigDecimal('-7e-19'))
# => -428571428571428571428571428571000000000 (bigdecimal-3.2.1)
# => -428571428571428571428571428571428571429 (expected result)
```
but this bug was fixed by a side effect of #377
