### PR TITLE
VpDivd bugfix

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -6019,12 +6019,6 @@ VpDivd(Real *c, Real *r, Real *a, Real *b)
 	VpSetZero(r, VpGetSign(a) * VpGetSign(b));
 	goto Exit;
     }
-    if (VpIsOne(b)) {
-	/* divide by one  */
-	VpAsgn(c, a, VpGetSign(b));
-	VpSetZero(r, VpGetSign(a));
-	goto Exit;
-    }
 
     word_a = a->Prec;
     word_b = b->Prec;
@@ -6057,15 +6051,14 @@ VpDivd(Real *c, Real *r, Real *a, Real *b)
 
     /* */
     /* loop start */
-    ind_c = word_r - 1;
-    nLoop = Min(word_c,ind_c);
+    nLoop = Min(word_c, word_r);
     ind_c = 1;
     while (ind_c < nLoop) {
 	if (r->frac[ind_c] == 0) {
 	    ++ind_c;
 	    continue;
 	}
-        r1r2 = (DECDIG_DBL)r->frac[ind_c] * BASE + r->frac[ind_c + 1];
+        r1r2 = (DECDIG_DBL)r->frac[ind_c] * BASE + (ind_c + 1 < word_r ? r->frac[ind_c + 1] : 0);
 	if (r1r2 == b1b2) {
 	    /* The first two word digits is the same */
 	    ind_b = 2;


### PR DESCRIPTION
Fix VpDivd bug which is a blocker of #371.

Fix rounding: VpDivd should always truncate. Remove wrong optimization that uses VpAsgn which rounds with the current rounding mode.
```ruby
VpDivd(div, rem, a, b)
a=0.9999999999 9999999999 9999999999 999000000E3 (1, 5, 5)
b=0.1E1 (1, 1, 1)

# Before
div=0.1000E4 (1, 1, 3) # Wrong. It shouldn't be rounded with the current rounding mode.
rem=0.0 # Wrong. It shouldn't be zero.

# After
div=0.9999999999 99000000E3 (1, 3, 3)
rem=0.9999999999 99000000E-18 (-2, 2, 6)
rem=0.9999999999 9999999999 9000000E-9
```

Fix VpDivd loop bug that sometimes skip calculating last DECDIG.

```ruby
# OK case
VpDivd(div, rem, a, b)
a=0.3000000000 0000000000 0000000000 0000000000 0000000000 0000000000 0001999999 999E73 (9, 9, 10)
b=0.10E2 (1, 1, 1)

div=0.3000000000 0000000000 0000000000 0000000000 0000000000 0000000000 0001999999 99E72 (8, 8, 10)
rem=0.9E1 (1, 1, 10)

# Bug case
VpDivd(div, rem, a, b)
a=0.3000000000 0000000000 0000000000 0000000000 0000000000 0000000000 0000999999 999E73 (9, 9, 10)
b=0.10E2 (1, 1, 1)

# Before. a, b, div, rem has same precision as OK case, but the last DECDIG calculation is somehow skipped
div=0.300000000E72 (8, 1, 10)
rem=0.999999999E9 (1, 1, 10)

# After
div=0.3000000000 0000000000 0000000000 0000000000 0000000000 0000000000 0000999999 99E72 (8, 8, 10)
rem=0.9E1 (1, 1, 10)
```
