### PR TITLE
Ignore ndigits passed to BigDecimal(string, ndigits)

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -3224,7 +3224,7 @@ rb_convert_to_BigDecimal(VALUE val, size_t digs, int raise_exception)
         return rb_convert_to_BigDecimal(rb_complex_real(val), digs, raise_exception);
     }
     else if (RB_TYPE_P(val, T_STRING)) {
-        return rb_str_convert_to_BigDecimal(val, digs, raise_exception);
+        return rb_str_convert_to_BigDecimal(val, 0, raise_exception);
     }
 
     /* TODO: chheck to_d */
@@ -3238,7 +3238,7 @@ rb_convert_to_BigDecimal(VALUE val, size_t digs, int raise_exception)
         }
         return Qnil;
     }
-    return rb_str_convert_to_BigDecimal(str, digs, raise_exception);
+    return rb_str_convert_to_BigDecimal(str, 0, raise_exception);
 }
 
 /*  call-seq:

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -113,6 +113,11 @@ class TestBigDecimal < Test::Unit::TestCase
     end
   end
 
+  def test_BigDecimal_ignore_digits
+    assert_equal(1, BigDecimal(1, LIMITS["FIXNUM_MAX"]))
+    assert_equal(1, BigDecimal('1', LIMITS["FIXNUM_MAX"]))
+  end
+
   def test_BigDecimal_bug7522
     bd = BigDecimal("1.12", 1)
     assert_same(bd, BigDecimal(bd))


### PR DESCRIPTION
Fixes #355
Don't allocate huge memory when huge ndigits is passed