### PR TITLE
Better error message for negative**intinite and zero-converge case fix

### DIFF
--- a/lib/bigdecimal.rb
+++ b/lib/bigdecimal.rb
@@ -48,6 +48,20 @@ class BigDecimal
 
     return BigDecimal::NAN if x.nan? || y.nan?
 
+    if y.infinite?
+      if x < 0
+        return BigDecimal(0) if x < -1 && y.negative?
+        return BigDecimal(0) if x > -1 && y.positive?
+        raise Math::DomainError, 'Result undefined for negative base raised to infinite power'
+      elsif x < 1
+        return y.positive? ? BigDecimal(0) : BigDecimal::INFINITY
+      elsif x == 1
+        return BigDecimal(1)
+      else
+        return y.positive? ? BigDecimal::INFINITY : BigDecimal(0)
+      end
+    end
+
     if x.zero?
       return BigDecimal(1) if y.zero?
       return BigDecimal(0) if y > 0
@@ -68,14 +82,6 @@ class BigDecimal
       end
     elsif x == 1
       return BigDecimal(1)
-    end
-
-    if y.infinite?
-      if x < 1
-        return y.positive? ? BigDecimal(0) : BigDecimal::INFINITY
-      else
-        return y.positive? ? BigDecimal::INFINITY : BigDecimal(0)
-      end
     end
 
     prec ||= BigDecimal.limit.nonzero?

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1840,12 +1840,20 @@ class TestBigDecimal < Test::Unit::TestCase
       assert_equal(1, BigDecimal(1) ** -BigDecimal::INFINITY)
       assert_positive_zero(BigDecimal(0) ** BigDecimal::INFINITY)
       assert_positive_infinite(BigDecimal(0) ** -BigDecimal::INFINITY)
-      assert_positive_zero(BigDecimal(-0) ** BigDecimal::INFINITY)
-      assert_positive_infinite(BigDecimal(-0) ** -BigDecimal::INFINITY)
-      assert_raise(Math::DomainError) { BigDecimal(-3) ** BigDecimal::INFINITY }
-      assert_raise(Math::DomainError) { BigDecimal(-3) ** -BigDecimal::INFINITY }
+      assert_positive_zero(BigDecimal(-0.0) ** BigDecimal::INFINITY)
+      assert_positive_infinite(BigDecimal(-0.0) ** -BigDecimal::INFINITY)
+
+      # negative_number ** infinite_number converge to zero
+      assert_positive_zero(BigDecimal(-2) ** -BigDecimal::INFINITY)
+      assert_positive_zero(BigDecimal(-0.5) ** BigDecimal::INFINITY)
+      assert_positive_zero((-BigDecimal::INFINITY) ** -BigDecimal::INFINITY)
+
+      # negative_number ** infinite_number that does not converge
+      assert_raise(Math::DomainError) { BigDecimal(-2) ** BigDecimal::INFINITY }
+      assert_raise(Math::DomainError) { BigDecimal(-0.5) ** -BigDecimal::INFINITY }
+      assert_raise(Math::DomainError) { BigDecimal(-1) ** BigDecimal::INFINITY }
+      assert_raise(Math::DomainError) { BigDecimal(-1) ** -BigDecimal::INFINITY }
       assert_raise(Math::DomainError) { (-BigDecimal::INFINITY) ** BigDecimal::INFINITY }
-      assert_raise(Math::DomainError) { (-BigDecimal::INFINITY) ** -BigDecimal::INFINITY }
     end
   end
 


### PR DESCRIPTION
'Computation results in complex number' is not a good error message for `(-2)**INFINITY`.
`(-2)**-INFINITY` and `(-0.5)**INFINITY` converge to zero.
