### PR TITLE
Coerce to bigdecimal refactor

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -399,17 +399,15 @@ static VALUE rb_cstr_convert_to_BigDecimal(const char *c_str, size_t digs, int r
 static VALUE rb_convert_to_BigDecimal(VALUE val, size_t digs, int raise_exception);
 
 static NULLABLE_BDVALUE
-GetBDValueWithPrecInternal(VALUE v, long prec, int must)
+GetBDValueWithPrecInternal(VALUE v, size_t prec, int must)
 {
-    const size_t digs = prec < 0 ? SIZE_MAX : (size_t)prec;
-
     switch(TYPE(v)) {
       case T_FLOAT:
-        v = rb_float_convert_to_BigDecimal(v, digs, must);
+        v = rb_float_convert_to_BigDecimal(v, 0, true);
         break;
 
       case T_RATIONAL:
-        v = rb_rational_convert_to_BigDecimal(v, digs, must);
+        v = rb_rational_convert_to_BigDecimal(v, prec, true);
         break;
 
       case T_DATA:
@@ -418,10 +416,9 @@ GetBDValueWithPrecInternal(VALUE v, long prec, int must)
         }
         break;
 
-      case T_FIXNUM: {
-        char szD[128];
-        snprintf(szD, 128, "%ld", FIX2LONG(v));
-        v = rb_cstr_convert_to_BigDecimal(szD, VpBaseFig() * 2 + 1, must);
+      case T_FIXNUM:
+      case T_BIGNUM: {
+        v = rb_inum_convert_to_BigDecimal(v);
         break;
       }
 
@@ -432,13 +429,6 @@ GetBDValueWithPrecInternal(VALUE v, long prec, int must)
         break;
       }
 #endif /* ENABLE_NUMERIC_STRING */
-
-      case T_BIGNUM: {
-	VALUE bg = rb_big2str(v, 10);
-        v = rb_cstr_convert_to_BigDecimal(RSTRING_PTR(bg), RSTRING_LEN(bg) + VpBaseFig() + 1, must);
-        RB_GC_GUARD(bg);
-        break;
-      }
 
       default:
 	goto SomeOneMayDoIt;
@@ -456,14 +446,14 @@ SomeOneMayDoIt:
 }
 
 static inline NULLABLE_BDVALUE
-GetBDValueWithPrec(VALUE v, long prec)
+GetBDValueWithPrec(VALUE v, size_t prec)
 {
     return GetBDValueWithPrecInternal(v, prec, 0);
 }
 
 
 static inline BDVALUE
-GetBDValueWithPrecMust(VALUE v, long prec)
+GetBDValueWithPrecMust(VALUE v, size_t prec)
 {
     return bdvalue_nonnullable(GetBDValueWithPrecInternal(v, prec, 1));
 }
@@ -472,19 +462,13 @@ GetBDValueWithPrecMust(VALUE v, long prec)
 static inline Real*
 GetSelfVpValue(VALUE self)
 {
-    return GetBDValueWithPrecMust(self, -1).real;
-}
-
-static inline NULLABLE_BDVALUE
-GetBDValue(VALUE v)
-{
-    return GetBDValueWithPrec(v, -1);
+    return GetBDValueWithPrecMust(self, 0).real;
 }
 
 static inline BDVALUE
 GetBDValueMust(VALUE v)
 {
-    return GetBDValueWithPrecMust(v, -1);
+    return GetBDValueWithPrecMust(v, 0);
 }
 
 /* call-seq:
@@ -1397,19 +1381,8 @@ BigDecimal_to_r(VALUE self)
 static VALUE
 BigDecimal_coerce(VALUE self, VALUE other)
 {
-    BDVALUE b;
-
-    if (RB_TYPE_P(other, T_FLOAT)) {
-        b = GetBDValueWithPrecMust(other, 0);
-    }
-    else if (RB_TYPE_P(other, T_RATIONAL)) {
-        Real* pv = DATA_PTR(self);
-        b = GetBDValueWithPrecMust(other, pv->Prec*VpBaseFig());
-    }
-    else {
-        b = GetBDValueMust(other);
-    }
-
+    Real* pv = DATA_PTR(self);
+    BDVALUE b = GetBDValueWithPrecMust(other, pv->Prec * BASE_FIG);
     return rb_assoc_new(CheckGetValue(b), self);
 }
 
@@ -1450,20 +1423,13 @@ static VALUE
 BigDecimal_add(VALUE self, VALUE r)
 {
     BDVALUE a, b, c;
+    NULLABLE_BDVALUE b2;
     size_t mx;
 
     a = GetBDValueMust(self);
-    if (RB_TYPE_P(r, T_FLOAT)) {
-        b = GetBDValueWithPrecMust(r, 0);
-    }
-    else if (RB_TYPE_P(r, T_RATIONAL)) {
-        b = GetBDValueWithPrecMust(r, a.real->Prec*VpBaseFig());
-    }
-    else {
-        NULLABLE_BDVALUE b2 = GetBDValue(r);
-        if (!b2.real_or_null) return DoSomeOne(self, r, '+');
-        b = bdvalue_nonnullable(b2);
-    }
+    b2 = GetBDValueWithPrec(r, a.real->Prec * BASE_FIG);
+    if (!b2.real_or_null) return DoSomeOne(self, r, '+');
+    b = bdvalue_nonnullable(b2);
 
     if (VpIsNaN(b.real)) return b.bigdecimal;
     if (VpIsNaN(a.real)) return a.bigdecimal;
@@ -1508,20 +1474,13 @@ static VALUE
 BigDecimal_sub(VALUE self, VALUE r)
 {
     BDVALUE a, b, c;
+    NULLABLE_BDVALUE b2;
     size_t mx;
 
     a = GetBDValueMust(self);
-    if (RB_TYPE_P(r, T_FLOAT)) {
-        b = GetBDValueWithPrecMust(r, 0);
-    }
-    else if (RB_TYPE_P(r, T_RATIONAL)) {
-        b = GetBDValueWithPrecMust(r, a.real->Prec*VpBaseFig());
-    }
-    else {
-        NULLABLE_BDVALUE b2 = GetBDValue(r);
-        if (!b2.real_or_null) return DoSomeOne(self, r, '-');
-        b = bdvalue_nonnullable(b2);
-    }
+    b2 = GetBDValueWithPrec(r, a.real->Prec * BASE_FIG);
+    if (!b2.real_or_null) return DoSomeOne(self, r, '-');
+    b = bdvalue_nonnullable(b2);
 
     if (VpIsNaN(b.real)) return b.bigdecimal;
     if (VpIsNaN(a.real)) return a.bigdecimal;
@@ -1552,29 +1511,8 @@ BigDecimalCmp(VALUE self, VALUE r,char op)
 {
     SIGNED_VALUE e;
     BDVALUE a = GetBDValueMust(self);
-    NULLABLE_BDVALUE b = { Qnil, NULL };
+    NULLABLE_BDVALUE b = GetBDValueWithPrec(r, a.real->Prec * BASE_FIG);
 
-    switch (TYPE(r)) {
-    case T_DATA:
-	if (!is_kind_of_BigDecimal(r)) break;
-	/* fall through */
-    case T_FIXNUM:
-	/* fall through */
-    case T_BIGNUM:
-	b = GetBDValue(r);
-	break;
-
-    case T_FLOAT:
-	b = GetBDValueWithPrec(r, 0);
-	break;
-
-    case T_RATIONAL:
-	b = GetBDValueWithPrec(r, a.real->Prec*VpBaseFig());
-	break;
-
-    default:
-	break;
-    }
     if (b.real_or_null == NULL) {
 	ID f = 0;
 
@@ -1804,19 +1742,12 @@ static VALUE
 BigDecimal_mult(VALUE self, VALUE r)
 {
     BDVALUE a, b, c;
+    NULLABLE_BDVALUE b2;
 
     a = GetBDValueMust(self);
-    if (RB_TYPE_P(r, T_FLOAT)) {
-        b = GetBDValueWithPrecMust(r, 0);
-    }
-    else if (RB_TYPE_P(r, T_RATIONAL)) {
-        b = GetBDValueWithPrecMust(r, a.real->Prec*VpBaseFig());
-    }
-    else {
-        NULLABLE_BDVALUE b2 = GetBDValue(r);
-        if (!b2.real_or_null) return DoSomeOne(self, r, '*');
-        b = bdvalue_nonnullable(b2);
-    }
+    b2 = GetBDValueWithPrec(r, a.real->Prec * BASE_FIG);
+    if (!b2.real_or_null) return DoSomeOne(self, r, '*');
+    b = bdvalue_nonnullable(b2);
 
     c = NewZeroWrapLimited(1, VPMULT_RESULT_PREC(a.real, b.real) * BASE_FIG);
     VpMult(c.real, a.real, b.real);
@@ -1902,30 +1833,15 @@ static VALUE
 BigDecimal_DoDivmod(VALUE self, VALUE r, NULLABLE_BDVALUE *div, NULLABLE_BDVALUE *mod, bool truncate)
 {
     BDVALUE a, b, dv, md, res;
+    NULLABLE_BDVALUE b2;
     ssize_t a_exponent, b_exponent;
     size_t mx, rx;
 
     a = GetBDValueMust(self);
 
-    VALUE rr = r;
-    if (is_kind_of_BigDecimal(rr)) {
-        /* do nothing */
-    }
-    else if (RB_INTEGER_TYPE_P(r)) {
-        rr = rb_inum_convert_to_BigDecimal(r);
-    }
-    else if (RB_TYPE_P(r, T_FLOAT)) {
-        rr = rb_float_convert_to_BigDecimal(r, 0, true);
-    }
-    else if (RB_TYPE_P(r, T_RATIONAL)) {
-        rr = rb_rational_convert_to_BigDecimal(r, a.real->Prec*BASE_FIG, true);
-    }
-
-    if (!is_kind_of_BigDecimal(rr)) {
-        return Qfalse;
-    }
-
-    b = GetBDValueMust(rr);
+    b2 = GetBDValueWithPrec(r, a.real->Prec * BASE_FIG);
+    if (!b2.real_or_null) return Qfalse;
+    b = bdvalue_nonnullable(b2);
 
     if (VpIsNaN(a.real) || VpIsNaN(b.real) || (VpIsInf(a.real) && VpIsInf(b.real))) {
         VALUE nan = BigDecimal_nan();
@@ -2099,15 +2015,7 @@ BigDecimal_div2(VALUE self, VALUE b, VALUE n)
     if (ix == 0) ix = pl;
 
     av = GetBDValueMust(self);
-    if (RB_FLOAT_TYPE_P(b) && ix > BIGDECIMAL_DOUBLE_FIGURES) {
-        /* TODO: I want to refactor this precision control for a float value later
-         *       by introducing an implicit conversion function instead of
-         *       GetBDValueWithPrecMust.  */
-        bv = GetBDValueWithPrecMust(b, BIGDECIMAL_DOUBLE_FIGURES);
-    }
-    else {
-        bv = GetBDValueWithPrecMust(b, ix);
-    }
+    bv = GetBDValueWithPrecMust(b, ix);
 
     if (ix == 0) {
         ssize_t a_prec, b_prec;

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1175,6 +1175,7 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_div_with_float
     assert_kind_of(BigDecimal, BigDecimal("3") / 1.5)
     assert_equal(BigDecimal("0.5"), BigDecimal(1) / 2.0)
+    assert_equal(BigDecimal(100), BigDecimal(7).div(0.07, 100))
   end
 
   def test_div_with_rational


### PR DESCRIPTION
Refactor this frequently appearing pattern. Many trivial variations but essentially doing the same thing.
```c
if (FLOAT) {
        convertToBigDecimal(arg, prec=0);
}
else if (RATIONAL)) {
        convertToBigDecimal(arg, prec=a->Prec * BASE_FIG);
}
else {
        convertToBigDecimal(arg, prec=-1)
}
```
and use
```c
b = GetBDValueWithPrecMust(other, a->Prec * BASE_FIG);
// or
b = GetBDValueWithPrec(other, a->Prec * BASE_FIG);
```

Duplicated code sometimes have very small difference. This behavior will change:
```ruby
BigDecimal(7).div(0.07, 18)
# => 0.999999999999999857e2 → 0.1e3
```

```ruby
bigdecimal.div(float, larger_than_16)

# was identical to this:
bigdecimal.div(BigDecimal(float, 16), larger_than_16)

# will be identical to these two:
bigdecimal.div(BigDecimal(float, 0), larger_than_16)
bigdecimal.div(BigDecimal(float), larger_than_16)
```

```ruby
bigdecimal.div(float, 5)

# was identical to:
bigdecimal.div(BigDecimal(float, 5), 5)
# will be identical to this. The result will be the same or more precise.
bigdecimal.div(BigDecimal(float, 0), 5)
```
I think the new behavior is more consistent and intuitive.
