### PR TITLE
Unify coerce prec calculation

### DIFF
--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -979,6 +979,17 @@ class TestBigDecimal < Test::Unit::TestCase
     end
   end
 
+  def test_coerce_rational
+    assert_in_epsilon(3.0 / 7.0, BigDecimal(1) / (7/3r), 1e-15)
+    assert_in_epsilon(10.0 / 3.0, BigDecimal(1) + (7/3r), 1e-15)
+    assert_in_epsilon(2.0 / 3.0, BigDecimal(3) - (7/3r), 1e-15)
+    assert_in_epsilon(14.0 / 3.0, BigDecimal(2) * (7/3r), 1e-15)
+    assert_in_epsilon(BigDecimal(3).div(7, 100), BigDecimal(1).div(7/3r, 100), 1e-99)
+    assert_in_epsilon(BigDecimal(10).div(3, 100), BigDecimal(1).add(7/3r, 100), 1e-99)
+    assert_in_epsilon(BigDecimal(2).div(3, 100), BigDecimal(3).sub(7/3r, 100), 1e-99)
+    assert_in_epsilon(BigDecimal(14).div(3, 100), BigDecimal(2).mult(7/3r, 100), 1e-99)
+  end
+
   def test_uplus
     x = BigDecimal("1")
     assert_equal(x, x.send(:+@))


### PR DESCRIPTION
Fixes #388
Unify coerce logic in add/sub/mult/div/coerce/cmp.
There are some differences. Unify them to div's precision calculation because add/sub/mult's calculation coerce Rational with low precision.
```ruby
# div
BigDecimal(1) / (3/7r) # Same as `BigDecimal(1) / BigDecimal(3/7r, 0)`
# => 0.233333333333333333333333333333332555555555555556e1 # ok
BigDecimal(1).div(3/7r, 50) # Same as `BigDecimal(1).div(BigDecimal(3/7r, 50), 50)`
# => 0.23333333333333333333333333333333333333333333333333e1 # ok

# add, sub, mult
BigDecimal(1) + (3/7r)
# before: 0.1428571429e1 (too low)
# after: 0.142857142857142857142857142857143e1 
BigDecimal(1).add(3/7r, 50)
# before: 0.1428571429e1 (too low)
# after: 0.14285714285714285714285714285714285714285714285714e1
```

Cmp with rational will change. The original behavior was weird.
```
10/3r == BigDecimal(10/3r, prec)
# before: always false
# after: always false

1/3r == BigDecimal(1/3r, prec)
# before: true when prec == 9*n (n>=1)

# after: true when prec == 9*n (prec >= 2*double_fig)
```