### PR TITLE
missing.h cleanup

### DIFF
--- a/ext/bigdecimal/extconf.rb
+++ b/ext/bigdecimal/extconf.rb
@@ -36,11 +36,6 @@ if have_header("intrin.h")
   have_func("_BitScanReverse64", "intrin.h")
 end
 
-have_func("labs", "stdlib.h")
-have_func("llabs", "stdlib.h")
-have_func("finite", "math.h")
-have_func("isfinite", "math.h")
-
 have_header("ruby/atomic.h")
 have_header("ruby/internal/has/builtin.h")
 have_header("ruby/internal/static_assert.h")

--- a/ext/bigdecimal/extconf.rb
+++ b/ext/bigdecimal/extconf.rb
@@ -40,8 +40,6 @@ have_header("ruby/atomic.h")
 have_header("ruby/internal/has/builtin.h")
 have_header("ruby/internal/static_assert.h")
 
-have_func("rb_rational_num", "ruby.h")
-have_func("rb_rational_den", "ruby.h")
 have_func("rb_complex_real", "ruby.h")
 have_func("rb_complex_imag", "ruby.h")
 have_func("rb_opts_exception_p", "ruby.h")

--- a/ext/bigdecimal/missing.h
+++ b/ext/bigdecimal/missing.h
@@ -8,14 +8,6 @@ extern "C" {
 #endif
 #endif
 
-#ifdef HAVE_STDLIB_H
-# include <stdlib.h>
-#endif
-
-#ifdef HAVE_MATH_H
-# include <math.h>
-#endif
-
 #ifndef RB_UNUSED_VAR
 # if defined(_MSC_VER) && _MSC_VER >= 1911
 #  define RB_UNUSED_VAR(x) x [[maybe_unused]]

--- a/ext/bigdecimal/missing.h
+++ b/ext/bigdecimal/missing.h
@@ -55,66 +55,8 @@ extern "C" {
 
 /* bool */
 
-#if defined(__bool_true_false_are_defined)
-# /* Take that. */
-
-#elif defined(HAVE_STDBOOL_H)
+#ifndef __bool_true_false_are_defined
 # include <stdbool.h>
-
-#else
-typedef unsigned char _Bool;
-# define bool _Bool
-# define true  ((_Bool)+1)
-# define false ((_Bool)-1)
-# define __bool_true_false_are_defined
-#endif
-
-/* abs */
-
-#ifndef HAVE_LABS
-static inline long
-labs(long const x)
-{
-    if (x < 0) return -x;
-    return x;
-}
-#endif
-
-#ifndef HAVE_LLABS
-static inline LONG_LONG
-llabs(LONG_LONG const x)
-{
-    if (x < 0) return -x;
-    return x;
-}
-#endif
-
-#ifdef vabs
-# undef vabs
-#endif
-#if SIZEOF_VALUE <= SIZEOF_INT
-# define vabs abs
-#elif SIZEOF_VALUE <= SIZEOF_LONG
-# define vabs labs
-#elif SIZEOF_VALUE <= SIZEOF_LONG_LONG
-# define vabs llabs
-#endif
-
-/* finite */
-
-#ifndef HAVE_FINITE
-static int
-finite(double)
-{
-    return !isnan(n) && !isinf(n);
-}
-#endif
-
-#ifndef isfinite
-# ifndef HAVE_ISFINITE
-#  define HAVE_ISFINITE 1
-#  define isfinite(x) finite(x)
-# endif
 #endif
 
 /* dtoa */

--- a/ext/bigdecimal/missing.h
+++ b/ext/bigdecimal/missing.h
@@ -62,32 +62,6 @@ extern "C" {
 /* dtoa */
 char *BigDecimal_dtoa(double d_, int mode, int ndigits, int *decpt, int *sign, char **rve);
 
-/* rational */
-
-#ifndef HAVE_RB_RATIONAL_NUM
-static inline VALUE
-rb_rational_num(VALUE rat)
-{
-#ifdef RRATIONAL
-    return RRATIONAL(rat)->num;
-#else
-    return rb_funcall(rat, rb_intern("numerator"), 0);
-#endif
-}
-#endif
-
-#ifndef HAVE_RB_RATIONAL_DEN
-static inline VALUE
-rb_rational_den(VALUE rat)
-{
-#ifdef RRATIONAL
-    return RRATIONAL(rat)->den;
-#else
-    return rb_funcall(rat, rb_intern("denominator"), 0);
-#endif
-}
-#endif
-
 /* complex */
 
 #ifndef HAVE_RB_COMPLEX_REAL


### PR DESCRIPTION
Remove unused and wrong `#define false 255` definition (bug. non-zero value is truethy)
Remove unused and wrong `static int finite(double){...}` definition (compile error)
Remove unused isfinite, vabs
Remove HAVE_RB_RATIONAL_NUM check (for ruby < 2.2)