### PR TITLE
Fix adjusting x to 0.3..3 in log calculation

### DIFF
--- a/lib/bigdecimal.rb
+++ b/lib/bigdecimal.rb
@@ -204,9 +204,9 @@ module BigMath
       log10 = log(BigDecimal(10), prec)
       exponent = x.exponent
       x = x * BigDecimal("1e#{-x.exponent}")
-      if x > 3
-        x /= 10
-        exponent += 1
+      if x < 0.3
+        x *= 10
+        exponent -= 1
       end
       return log10 * exponent + log(x, prec)
     end


### PR DESCRIPTION
Range of `x = x * BigDecimal("1e#{-x.exponent}")` is in `0.1...1.0`.
The code was wrongly assumes that the range is `1.0...10.0`
