### PR TITLE
Faster exp calculation

### DIFF
--- a/lib/bigdecimal.rb
+++ b/lib/bigdecimal.rb
@@ -248,6 +248,18 @@ module BigMath
     y.mult(2 ** (sqrt_steps + 1), prec)
   end
 
+  private_class_method def self._exp_taylor(x, prec) # :nodoc:
+    xn = BigDecimal(1)
+    y = BigDecimal(1)
+    1.step do |i|
+      n = prec + xn.exponent
+      break if n <= 0 || xn.zero?
+      xn = xn.mult(x, n).div(i, n)
+      y = y.add(xn, prec)
+    end
+    y
+  end
+
   # call-seq:
   #   BigMath.exp(decimal, numeric)    -> BigDecimal
   #
@@ -270,17 +282,12 @@ module BigMath
     cnt = x > 1 ? x.exponent : 0
     prec2 = prec + BigDecimal.double_fig + cnt
     x *= BigDecimal("1e-#{cnt}")
-    xn = BigDecimal(1)
-    y = BigDecimal(1)
 
-    # Taylor series for exp(x) around 0
-    1.step do |i|
-      n = prec2 + xn.exponent
-      break if n <= 0 || xn.zero?
-      x = x.mult(1, n)
-      xn = xn.mult(x, n).div(i, n)
-      y = y.add(xn, prec2)
-    end
+    # Calculation of exp(small_prec) is fast because calculation of x**n is fast
+    # Calculation of exp(small_abs) converges fast.
+    # exp(x) = exp(small_prec_part + small_abs_part) = exp(small_prec_part) * exp(small_abs_part)
+    x_small_prec = x.round(Integer.sqrt(prec2))
+    y = _exp_taylor(x_small_prec, prec2).mult(_exp_taylor(x - x_small_prec, prec2), prec2)
 
     # calculate exp(x * 10**cnt) from exp(x)
     # exp(x * 10**k) = exp(x * 10**(k - 1)) ** 10


### PR DESCRIPTION
Use `exp(x) = exp(x.round(k)) * exp(x - x.round(k))`.
`exp(x.round(k))` is fast because calculation of `x**n` is fast.
`exp(x-x.round(k)` is fast because `x**n/n!` converges fast.

```ruby
BigMath.exp(1, 10000);
# 0.062810s → 0.062706s (no difference)

BigMath.exp(BigDecimal(3).div(7, 1000), 1000)
# 0.01463742s → 0.00326753s

BigMath.exp(BigDecimal(3).div(7, 10000), 10000)
# 8.571512s -> 0.552467s
```

## Why this optimization?
Currently, `exp(x)` uses `exp(x/10**cnt)**(10**cnt)` to make `|x|<1`.
We can make `|x|` even smaller, but the computation cost of `y**10` is large currently `O(prec**2)`.
`exp(x) = exp(x.round(k)) * exp(x - x.round(k))` might not be optimal for the long run, but considering the simplicity of the change, improvement is significant and worth enough.
```diff
- y = _exp_taylor(x, prec2)
+ x_small_prec = x.round(Integer.sqrt(prec2))
+ y = _exp_taylor(x_small_prec, prec2).mult(_exp_taylor(x - x_small_prec, prec2), prec2)
```

