### PR TITLE
Fix PrecLimit not restored on exception

### DIFF
--- a/ext/bigdecimal/bigdecimal.h
+++ b/ext/bigdecimal/bigdecimal.h
@@ -205,7 +205,7 @@ VP_EXPORT double VpGetDoubleNegZero(void);
 
 /* These 2 functions added at v1.1.7 */
 VP_EXPORT size_t VpGetPrecLimit(void);
-VP_EXPORT size_t VpSetPrecLimit(size_t n);
+VP_EXPORT void VpSetPrecLimit(size_t n);
 
 /* Round mode */
 VP_EXPORT int            VpIsRoundMode(unsigned short n);


### PR DESCRIPTION
Fixes #404

The scope of changing PrecLimit was large.
```c
pl = VpSetPrecLimit(0);
// Doing many operations here
VpSetPrecLimit(pl);
```
If an exception occurs, PrecLimit won't be restored correctly.



Also fixes this performance issue
```ruby
BigDecimal('1e9999999999').add(1, 10)
processing time: 1.831897s → 0.000162s
=> 0.1e10000000000
```