### PR TITLE
Fix x.fix and x.frac affected by prec limit, Stop -x and x.abs round with prec limit

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -1702,8 +1702,8 @@ static VALUE
 BigDecimal_neg(VALUE self)
 {
     BDVALUE a = GetBDValueMust(self);
-    BDVALUE c = NewZeroWrapLimited(1, a.real->Prec * BASE_FIG);
-    VpAsgn(c.real, a.real, -1);
+    BDVALUE c = NewZeroWrapNolimit(1, a.real->Prec * BASE_FIG);
+    VpAsgn(c.real, a.real, -10);
     RB_GC_GUARD(a.bigdecimal);
     return CheckGetValue(c);
 }
@@ -2176,8 +2176,8 @@ static VALUE
 BigDecimal_abs(VALUE self)
 {
     BDVALUE a = GetBDValueMust(self);
-    BDVALUE c = NewZeroWrapLimited(1, a.real->Prec * BASE_FIG);
-    VpAsgn(c.real, a.real, 1);
+    BDVALUE c = NewZeroWrapNolimit(1, a.real->Prec * BASE_FIG);
+    VpAsgn(c.real, a.real, 10);
     VpChangeSign(c.real, 1);
     RB_GC_GUARD(a.bigdecimal);
     return CheckGetValue(c);
@@ -2215,7 +2215,7 @@ static VALUE
 BigDecimal_fix(VALUE self)
 {
     BDVALUE a = GetBDValueMust(self);
-    BDVALUE c = NewZeroWrapLimited(1, (a.real->Prec + 1) * BASE_FIG);
+    BDVALUE c = NewZeroWrapNolimit(1, (a.real->Prec + 1) * BASE_FIG);
     VpActiveRound(c.real, a.real, VP_ROUND_DOWN, 0); /* 0: round off */
     RB_GC_GUARD(a.bigdecimal);
     return CheckGetValue(c);
@@ -2359,7 +2359,7 @@ static VALUE
 BigDecimal_frac(VALUE self)
 {
     BDVALUE a = GetBDValueMust(self);
-    BDVALUE c = NewZeroWrapLimited(1, (a.real->Prec + 1) * BASE_FIG);
+    BDVALUE c = NewZeroWrapNolimit(1, (a.real->Prec + 1) * BASE_FIG);
     VpFrac(c.real, a.real);
     RB_GC_GUARD(a.bigdecimal);
     return CheckGetValue(c);

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -2051,6 +2051,31 @@ class TestBigDecimal < Test::Unit::TestCase
     end
   end
 
+  def test_sign_operator_ignores_limit
+    plus_x = BigDecimal('7' * 100)
+    minus_x = -plus_x
+    BigDecimal.save_limit do
+      BigDecimal.limit(3)
+      assert_equal(plus_x, +plus_x)
+      assert_equal(minus_x, +minus_x)
+      assert_equal(minus_x, -plus_x)
+      assert_equal(plus_x, -minus_x)
+      assert_equal(plus_x, minus_x.abs)
+      assert_equal(plus_x, plus_x.abs)
+    end
+  end
+
+  def test_fix_frac_ignores_limit
+    fix = BigDecimal("#{'4' * 56}")
+    frac = BigDecimal("0.#{'7' * 89}")
+    x = fix + frac
+    BigDecimal.save_limit do
+      BigDecimal.limit(3)
+      assert_equal(fix, x.fix)
+      assert_equal(frac, x.frac)
+    end
+  end
+
   def test_sign
     BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)


### PR DESCRIPTION
Stop round/truncate in `fix` `frac` `abs` `-@` when prec limit is set

Fixes this bug
```ruby
BigDecimal.limit(1)
x=BigDecimal("#{'7'*1000}.#{'7'*1000}")
# fix and frac are not rounded with prec=1 but truncated
x.fix  #=> 0.7777777777777777777e1000
x.frac #=> 0.777777777777777777777777777e0
x.fix + x.frac == x #=> false
```

Stop rounding in `-@` and `abs`. Fixes inconsistency between `+@` and `-@`
```ruby
BigDecimal.limit(1)
x = BigDecimal(12345)
+x #=> 0.12345e5
-x #=> -0.1e5 → -0.12345e5
x.abs #=> 0.1e5 → 0.12345e5
```

Solves this problem
```ruby
def f(x, prec)
  return f(-x, prec) if x < 0 # -@ drops precision
  # Workaround: return f(x.mult(-1, prec), prec) if x < 0
  calculation_for_positive_case
end

def g(x, prec)
  BigMath.log(x.abs, prec).mult(x, prec) # x.abs drops precision
  # Workaround: BigMath.log(x > 0 ? x : x.mult(-1, prec), prec).mult(x, prec)
end
```
