### PR TITLE
Don't use ZeroWrapLimited. Use unlimited version instead.

### DIFF
--- a/ext/bigdecimal/bigdecimal.h
+++ b/ext/bigdecimal/bigdecimal.h
@@ -215,7 +215,7 @@ VP_EXPORT unsigned short VpSetRoundMode(unsigned short n);
 VP_EXPORT int VpException(unsigned short f,const char *str,int always);
 VP_EXPORT size_t VpNumOfChars(Real *vp,const char *pszFmt);
 VP_EXPORT size_t VpInit(DECDIG BaseVal);
-VP_EXPORT Real *VpAlloc(size_t mx, const char *szVal, int strict_p, int exc);
+VP_EXPORT Real *VpAlloc(const char *szVal, int strict_p, int exc);
 VP_EXPORT size_t VpAsgn(Real *c, Real *a, int isw);
 VP_EXPORT size_t VpAddSub(Real *c,Real *a,Real *b,int operation);
 VP_EXPORT size_t VpMult(Real *c,Real *a,Real *b);

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -150,6 +150,7 @@ class TestBigDecimal < Test::Unit::TestCase
     bd = BigDecimal("1.12", 1)
     assert_same(bd, BigDecimal(bd))
     assert_same(bd, BigDecimal(bd, exception: false))
+    assert_equal(bd, BigDecimal(bd, 1))
     assert_not_same(bd, BigDecimal(bd, 1))
     assert_not_same(bd, BigDecimal(bd, 1, exception: false))
   end


### PR DESCRIPTION
Auto limit allocation is not so good.
After several refactoring and bug fixes, `ZeroWrapLimited` turned out to be useless in most cases.
It allocates with extra `Max(extra_sub_prec, extra_rounding_prec, extra_div_prec, extra_sqrt_prec, ...)` DECDIGs. This value 2 is hardcoded.
In a few case that ZeroWrapLimited is really needed, explicitly calculate precision is enough.
```c
// Before
NewZeroWrapLimited(1, mx + extra); // Be sure extra <= 2*BASE_FIG because NewZeroWrapLimited hardcodes 2

// After
if (prec == 0 && prec_limit) mx = prec_limit;
NewZeroWrap(1, mx + extra); // extra can be any value
```

Remaining `NewZeroWrapLimited` and `NewOneNolimit` is only used in `sqrt` and will be removed in #381