### PR TITLE
Fix `x / y` precision when prec limit is huge

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -1905,18 +1905,17 @@ BigDecimal_div2(VALUE self, VALUE b, VALUE n)
     /* div in BigDecimal sense */
     ix = check_int_precision(n);
 
-    if (ix == 0) ix = VpGetPrecLimit();
-
     av = GetBDValueMust(self);
     bv = GetBDValueWithPrecMust(b, GetCoercePrec(av.real, ix));
 
     if (ix == 0) {
-        ssize_t a_prec, b_prec;
+        ssize_t a_prec, b_prec, limit = VpGetPrecLimit();
         VpCountPrecisionAndScale(av.real, &a_prec, NULL);
         VpCountPrecisionAndScale(bv.real, &b_prec, NULL);
         ix = ((a_prec > b_prec) ? a_prec : b_prec) + BIGDECIMAL_DOUBLE_FIGURES;
         if (2 * BIGDECIMAL_DOUBLE_FIGURES > ix)
             ix = 2 * BIGDECIMAL_DOUBLE_FIGURES;
+        if (limit && limit < ix) ix = limit;
     }
 
     // Needs to calculate 1 extra digit for rounding.

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -2032,6 +2032,15 @@ class TestBigDecimal < Test::Unit::TestCase
     end
   end
 
+  def test_div_with_huge_limit
+    BigDecimal.save_limit do
+      x, y = BigDecimal(2), BigDecimal(3)
+      div = x / y
+      BigDecimal.limit(1000)
+      assert_equal(div, x / y)
+    end
+  end
+
   def test_div_mod_rem_operation_with_limit
     x = -(9 ** 100)
     y = 7 ** 100


### PR DESCRIPTION
When prec limit set to 10000, BigDecimal(2)/3 was calculated in 10000 digits.
Fixes it to calcualte in 32 digits. Prec limit is just a limit.

```ruby
BigDecimal(2)/3
# => 0.66666666666666666666666666666667e0

BigDecimal.limit(1000000) # This is just a limit. Not a precision for arithmetic operation.

BigDecimal(2)/3
# => 0.66666666666666666666666666666667e0 (This pull request)
# => 0.6666666666666666666666666666666...66666666666666666666666666666667 (bug)
```