### PR TITLE
Simplify to_i logic

### DIFF
--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -928,8 +928,10 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_raise(FloatDomainError) {( 0 / x).to_i}
     x = BigDecimal("1")
     assert_equal(1, x.to_i)
-    x = BigDecimal((2**100).to_s)
-    assert_equal(2**100, x.to_i)
+
+    assert_equal(2**100, BigDecimal(2**100).to_i)
+    assert_equal(2**100 / 10**50, BigDecimal("#{2**100}e-50").to_i)
+    assert_equal(2**100 * 10**50, BigDecimal("#{2**100}e50").to_i)
   end
 
   def test_to_f


### PR DESCRIPTION
`x = x.fix` before converting to string

Original to_i logic:
```ruby
# exponent > prec
BigDecimal('0.123456789e13').to_i
'123456789'.to_i * 10**4

# exponent < prec
BigDecimal('123.456789').to_i
'123456789'.to_i / 10**6
```
Using `x = x.fix`, we don't need the latter division logic.

As a side effect, `to_i` will be fast in a few edge case.
```ruby
x = BigDecimal('1111111111.' + '1' * 100000000)
x.to_i # 9.096518s → 0.013209s
```