### PR TITLE
Add BigMath::E and BigMath::PI precision test

### DIFF
--- a/test/bigdecimal/test_bigmath.rb
+++ b/test/bigdecimal/test_bigmath.rb
@@ -13,9 +13,20 @@ class TestBigMath < Test::Unit::TestCase
   MINF = BigDecimal("-Infinity")
   NAN = BigDecimal("NaN")
 
-  def test_const
-    assert_in_delta(Math::PI, PI(N))
-    assert_in_delta(Math::E, E(N))
+  def test_pi
+    assert_equal(
+      BigDecimal("3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068"),
+      PI(100).round(100)
+    )
+    assert_relative_precision {|n| PI(n) }
+  end
+
+  def test_e
+    assert_equal(
+      BigDecimal("2.718281828459045235360287471352662497757247093699959574966967627724076630353547594571382178525166427"),
+      E(100)
+    )
+    assert_relative_precision {|n| E(n) }
   end
 
   def test_sqrt


### PR DESCRIPTION
PI and E are already indirectly tested in `cos(PI(100) / 6, 100)` and in `test_exp`, but it's better to have an explicit precision test.

Related to #238