### PR TITLE
BigMath methods common interface: coerce x, validate prec, check nan error

### DIFF
--- a/lib/bigdecimal/math.rb
+++ b/lib/bigdecimal/math.rb
@@ -41,6 +41,8 @@ module BigMath
   #   #=> "0.1414213562373095048801688724e1"
   #
   def sqrt(x, prec)
+    BigDecimal::Internal.validate_prec(prec, :sqrt)
+    x = BigDecimal::Internal.coerce_to_bigdecimal(x, prec, :sqrt)
     x.sqrt(prec)
   end
 
@@ -83,8 +85,9 @@ module BigMath
   #   #=> "0.70710678118654752440082036563292800375e0"
   #
   def sin(x, prec)
-    raise ArgumentError, "Zero or negative precision for sin" if prec <= 0
-    return BigDecimal("NaN") if x.infinite? || x.nan?
+    BigDecimal::Internal.validate_prec(prec, :sin)
+    x = BigDecimal::Internal.coerce_to_bigdecimal(x, prec, :sin)
+    return BigDecimal::Internal.nan_computation_result if x.infinite? || x.nan?
     n    = prec + BigDecimal.double_fig
     one  = BigDecimal("1")
     two  = BigDecimal("2")
@@ -119,8 +122,9 @@ module BigMath
   #   #=> "-0.999999999999999999999999999999856613163740061349e0"
   #
   def cos(x, prec)
-    raise ArgumentError, "Zero or negative precision for cos" if prec <= 0
-    return BigDecimal("NaN") if x.infinite? || x.nan?
+    BigDecimal::Internal.validate_prec(prec, :cos)
+    x = BigDecimal::Internal.coerce_to_bigdecimal(x, prec, :cos)
+    return BigDecimal::Internal.nan_computation_result if x.infinite? || x.nan?
     sign, x = _sin_periodic_reduction(x, prec + BigDecimal.double_fig, add_half_pi: true)
     sign * sin(x, prec)
   end
@@ -140,6 +144,7 @@ module BigMath
   #   #=> "0.99999999999999999999419869652481995799388629632650769e0"
   #
   def tan(x, prec)
+    BigDecimal::Internal.validate_prec(prec, :tan)
     sin(x, prec) / cos(x, prec)
   end
 
@@ -155,8 +160,9 @@ module BigMath
   #   #=> "-0.785398163397448309615660845819878471907514682065e0"
   #
   def atan(x, prec)
-    raise ArgumentError, "Zero or negative precision for atan" if prec <= 0
-    return BigDecimal("NaN") if x.nan?
+    BigDecimal::Internal.validate_prec(prec, :atan)
+    x = BigDecimal::Internal.coerce_to_bigdecimal(x, prec, :atan)
+    return BigDecimal::Internal.nan_computation_result if x.nan?
     pi = PI(prec)
     x = -x if neg = x < 0
     return pi.div(neg ? -2 : 2, prec) if x.infinite?
@@ -192,7 +198,7 @@ module BigMath
   #   #=> "0.3141592653589793238462643388813853786957412e1"
   #
   def PI(prec)
-    raise ArgumentError, "Zero or negative precision for PI" if prec <= 0
+    BigDecimal::Internal.validate_prec(prec, :PI)
     n      = prec + BigDecimal.double_fig
     zero   = BigDecimal("0")
     one    = BigDecimal("1")
@@ -237,7 +243,7 @@ module BigMath
   #   #=> "0.271828182845904523536028752390026306410273e1"
   #
   def E(prec)
-    raise ArgumentError, "Zero or negative precision for E" if prec <= 0
+    BigDecimal::Internal.validate_prec(prec, :E)
     BigMath.exp(1, prec)
   end
 end

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -2484,7 +2484,8 @@ class TestBigDecimal < Test::Unit::TestCase
     BigDecimal.save_limit do
       BigDecimal.limit(limit)
       assert_equal(sqrt, BigMath.sqrt(x, prec))
-      assert_equal(sqrt_lim, BigMath.sqrt(x, 0))
+      assert_equal(sqrt, x.sqrt(prec))
+      assert_equal(sqrt_lim, x.sqrt(0))
       assert_equal(exp, BigMath.exp(x, prec))
       assert_equal(log, BigMath.log(x, prec))
       assert_equal(pow, x.power(y, prec))


### PR DESCRIPTION
Needs #420 to be merged.

Common interface of `BigMath.func(x, prec)`

### Changes
Numeric arg are coreced into BigDecimal
```ruby
# These works
BigMath.exp(2, 100)
BigMath.log(2, 100)
# These weren't. Now all works.
BigMath.sqrt(2, 100)
BigMath.sin(2, 100)
BigMath.cos(2, 100)
BigMath.atan(2, 100)
```

Prec validations are now all same.
```ruby
# Zero or negative precision for [method_name] (ArgumentError)
BigMath.exp(x, 0)
BigMath.log(x, 0)
BigMath.sin(x, 0)
# This was accepted before. Error now.
BigMath.sqrt(x, 0)

# precision must be an Integer (ArgumentError)
BigMath.log(x, 10.0)
BigMath.exp(x, 10.0) # accepted in bigdecimal 3.2.2, error in current master branch
# These were accepted before. Error now.
BigMath.sqrt(x, 10.0)
BigMath.sin(x, 10.0)
BigMath.cos(x, 10.0)
BigMath.atan(x, 10.0)
```
