### PR TITLE
Update bigdecimal version used in benchmark from 3.0.0 to 3.1.1

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install dependencies
       run: |
         bundle install
-        gem install bigdecimal -v 3.0.0
+        gem install bigdecimal -v 3.1.1
 
     - run: rake compile
 

--- a/benchmark/from_float.yml
+++ b/benchmark/from_float.yml
@@ -2,7 +2,7 @@ loop_count: 100000
 
 contexts:
 - gems:
-    bigdecimal: 3.0.0
+    bigdecimal: 3.1.1
 - name: "master"
   prelude: |-
     $LOAD_PATH.unshift(File.expand_path("lib"))

--- a/benchmark/from_large_integer.yml
+++ b/benchmark/from_large_integer.yml
@@ -2,7 +2,7 @@ loop_count: 1000
 
 contexts:
 - gems:
-    bigdecimal: 3.0.0
+    bigdecimal: 3.1.1
 - name: "master"
   prelude: |-
     $LOAD_PATH.unshift(File.expand_path("lib"))

--- a/benchmark/from_small_integer.yml
+++ b/benchmark/from_small_integer.yml
@@ -2,7 +2,7 @@ loop_count: 100000
 
 contexts:
 - gems:
-    bigdecimal: 3.0.0
+    bigdecimal: 3.1.1
 - name: "master"
   prelude: |-
     $LOAD_PATH.unshift(File.expand_path("lib"))


### PR DESCRIPTION
GitHub actions macos-latest has been updated to macos-15, and `gem install bigdecimal -v 3.0.0` began to fail.

GH-Actions failing log
```
Operating System
  macOS
  15.5

...

Run bundle install
  bundle install
  gem install bigdecimal -v 3.0.0

...
ERROR:  Error installing bigdecimal:
	ERROR: Failed to build gem native extension.
...
compiling bigdecimal.c
bigdecimal.c:249:5: error: 'maybe_unused' attribute cannot be applied to types
  249 |     ENTER(1);
      |     ^
```
This problem seems to be fixed in https://github.com/ruby/bigdecimal/commit/6d510e47bce2ba4dbff4c48c26ee8d5cd8de1758 (released as bigdecimal-3.1.0)
Use bigdecimal 3.1.1 which is bundled in ruby-3.1.0