### PR TITLE
In JRuby, don't add sqrt, exp, log, power implemented in ruby

### DIFF
--- a/lib/bigdecimal.rb
+++ b/lib/bigdecimal.rb
@@ -1,5 +1,6 @@
 if RUBY_ENGINE == 'jruby'
   JRuby::Util.load_ext("org.jruby.ext.bigdecimal.BigDecimalLibrary")
+  return
 else
   require 'bigdecimal.so'
 end


### PR DESCRIPTION
Stub out ruby-implemented methods (`sqrt` `exp` `log` `power`) in JRuby for now.
These methods already exist in JRuby.
It depends on new feature only implemented in bigdecimal.c: `BigDecimal(float_without_prec)` and `BigDecimal#_decimal_shift`

There are some utility functions in `lib/bigdecimal/bigdecimal.rb`: `BigDecimal::Internal.coerce_to_bigdecimal`, `BigDecimal::Internal.validate_prec`, etc.
I want to use them in BigMath in the future. At that time, I think we need to remove this `return` and fix the ruby code.
