### PR TITLE
Add JRuby minimum ci

### DIFF
--- a/.github/workflows/jruby_test.yml
+++ b/.github/workflows/jruby_test.yml
@@ -1,0 +1,40 @@
+name: JRuby-test
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+
+jobs:
+  host:
+    name: ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - jruby
+          - jruby-head
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - run: bundle install
+
+      - run: rake compile
+
+      - run: rake test TEST=test/bigdecimal/test_jruby.rb
+
+      - run: rake build
+
+      - run: gem install pkg/*.gem

--- a/test/bigdecimal/test_jruby.rb
+++ b/test/bigdecimal/test_jruby.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: false
+require_relative 'helper'
+require 'bigdecimal/math'
+
+class TestJRuby < Test::Unit::TestCase
+  # JRuby uses its own native BigDecimal implementation
+  # but uses the same BigMath module as CRuby.
+  # These are test to ensure BigMath works correctly with JRuby's BigDecimal.
+  # Also run on CRuby to ensure compatibility.
+
+  N = 20
+
+  def test_sqrt
+    sqrt2 = BigDecimal(2).sqrt(N)
+    assert_in_delta(Math.sqrt(2), sqrt2)
+    assert_in_delta(2, sqrt2 * sqrt2)
+  end
+
+  def test_exp
+    assert_in_delta(Math.exp(2), BigMath.exp(BigDecimal(2), N))
+    assert_in_delta(Math.exp(2), BigMath.exp(2, N))
+    assert_in_delta(Math.exp(2.5), BigMath.exp(2.5, N))
+    assert_in_delta(Math.exp(2.5), BigMath.exp(2.5r, N))
+  end
+
+  def test_log
+    assert_in_delta(Math.log(2), BigMath.log(BigDecimal(2), N))
+    assert_in_delta(Math.log(2), BigMath.log(2, N))
+    assert_in_delta(Math.log(2.5), BigMath.log(2.5, N))
+    assert_in_delta(Math.log(2.5), BigMath.log(2.5r, N))
+  end
+
+  def test_power
+    x = BigDecimal(2)
+    expected = 2 ** 2.5
+    assert_in_delta(expected, x ** BigDecimal('2.5'))
+    assert_in_delta(expected, x.sqrt(N) ** 5)
+    # assert_in_delta(expected, x ** 2.5)
+    assert_in_delta(expected, x ** 2.5r)
+    assert_in_delta(expected, x.power(BigDecimal('2.5'), N))
+    # assert_in_delta(expected, x.power(2.5, N))
+    assert_in_delta(expected, x.sqrt(N).power(5, N))
+    assert_in_delta(expected, x.power(2.5r, N))
+  end
+
+  def test_bigmath
+    assert_in_delta(Math.sqrt(2), BigMath.sqrt(BigDecimal(2), N))
+    assert_in_delta(Math.sin(1), BigMath.sin(BigDecimal(1), N))
+    assert_in_delta(Math.cos(1), BigMath.cos(BigDecimal(1), N))
+    assert_in_delta(Math.atan(1), BigMath.atan(BigDecimal(1), N))
+    assert_in_delta(Math::PI, BigMath.PI(N))
+    assert_in_delta(Math::E, BigMath.E(N))
+  end
+end


### PR DESCRIPTION
Modifying `bigdecimal/math.rb` might break JRuby. One example is #415.

JRuby uses its own native implementation, but uses the same ruby-implemented BigMath implementation.
Adds a minimum ci to ensure BigMath methods works in JRuby.



```ruby
# Commented out two assertion because it's failing in jruby 10.0.2.0 (passes in jruby 9.4.9.0)
assert_in_delta(2 ** 2.5, BigDecimal(2) ** 2.5)
assert_in_delta(2 ** 2.5, BigDecimal(2).power(2.5, N))
# <5.656854249492381> -/+ <0.001> was expected to include
#   <0.4e1>.
```