### PR TITLE
Bump version to 3.2.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,21 @@
 # CHANGES
 
+## 3.2.3
+
+* Allow BigDecimal accept Float without precision [GH-314]
+
+  **@mrzasa**
+
+* Ruby implementation pow, log, exp and sqrt [GH-347] [GH-381]
+
+  **@tompng**
+
+* Update document [GH-348] [GH-360] [GH-365]
+
+  **@timcraft** **@dduugg** **@mame**
+
+* Lots of bug fixes and refactoring
+
 ## 3.2.2
 
 * Make precision calculation in bigdecimal.div(value, 0) gc-compaction safe. [GH-340]

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -31,7 +31,7 @@
 #include "bits.h"
 #include "static_assert.h"
 
-#define BIGDECIMAL_VERSION "3.2.2"
+#define BIGDECIMAL_VERSION "3.2.3"
 
 /* #define ENABLE_NUMERIC_STRING */
 


### PR DESCRIPTION
- Allow BigDecimal accept Float without precision
- `**`, `exp`, `log`, `power` and `sqrt` are now implemented in Ruby
- Bug fixes, refactoring, internal data structure change
  - `ext/*`: 1662 deletions
  - `lib/*`: 327 additions

https://github.com/ruby/bigdecimal/compare/v3.2.2...master
