### PR TITLE
Make bigdecimal.rb work in JRuby

### DIFF
--- a/lib/bigdecimal.rb
+++ b/lib/bigdecimal.rb
@@ -1,6 +1,17 @@
 if RUBY_ENGINE == 'jruby'
   JRuby::Util.load_ext("org.jruby.ext.bigdecimal.BigDecimalLibrary")
-  return
+
+  class BigDecimal
+    def _decimal_shift(i) # :nodoc:
+      # Creating a large exponent number with move_point_left/right is slow.
+      # Avoid it by multiplying/dividing with small exponent number.
+      if i < 0
+        mult(BigDecimal(1).to_java.move_point_left(-i).to_d, n_significant_digits)
+      else
+        div(BigDecimal(1).to_java.move_point_left(i).to_d, n_significant_digits)
+      end
+    end
+  end
 else
   require 'bigdecimal.so'
 end
@@ -15,7 +26,7 @@ class BigDecimal
       when BigDecimal
         return x
       when Integer, Float
-        return BigDecimal(x)
+        return BigDecimal(x, 0)
       when Rational
         return BigDecimal(x, [prec, 2 * BigDecimal.double_fig].max)
       end
@@ -199,7 +210,7 @@ class BigDecimal
 
     ex = exponent / 2
     x = _decimal_shift(-2 * ex)
-    y = BigDecimal(Math.sqrt(x.to_f))
+    y = BigDecimal(Math.sqrt(x.to_f), 0)
     precs = [prec + BigDecimal.double_fig]
     precs << 2 + precs.last / 2 while precs.last > BigDecimal.double_fig
     precs.reverse_each do |p|

--- a/test/bigdecimal/test_jruby.rb
+++ b/test/bigdecimal/test_jruby.rb
@@ -10,6 +10,13 @@ class TestJRuby < Test::Unit::TestCase
 
   N = 20
 
+  def test_decimal_shift_polyfill
+    assert_equal(BigDecimal('123.45e2'), BigDecimal('123.45')._decimal_shift(2))
+    assert_equal(BigDecimal('123.45e-2'), BigDecimal('123.45')._decimal_shift(-2))
+    assert_equal(BigDecimal('123.45e10000'), BigDecimal('123.45')._decimal_shift(10000))
+    assert_equal(BigDecimal('123.45e-10000'), BigDecimal('123.45')._decimal_shift(-10000))
+  end
+
   def test_sqrt
     sqrt2 = BigDecimal(2).sqrt(N)
     assert_in_delta(Math.sqrt(2), sqrt2)
@@ -35,10 +42,10 @@ class TestJRuby < Test::Unit::TestCase
     expected = 2 ** 2.5
     assert_in_delta(expected, x ** BigDecimal('2.5'))
     assert_in_delta(expected, x.sqrt(N) ** 5)
-    # assert_in_delta(expected, x ** 2.5)
+    assert_in_delta(expected, x ** 2.5)
     assert_in_delta(expected, x ** 2.5r)
     assert_in_delta(expected, x.power(BigDecimal('2.5'), N))
-    # assert_in_delta(expected, x.power(2.5, N))
+    assert_in_delta(expected, x.power(2.5, N))
     assert_in_delta(expected, x.sqrt(N).power(5, N))
     assert_in_delta(expected, x.power(2.5r, N))
   end


### PR DESCRIPTION
Use `BigDecimal(float, 0)` instead of `BigDecimal(float)`.
Add a ruby-implemented polyfill of `BigDecimal#_decimal_shift`.
This is needed to let `math.rb` depend on `bigdecimal.rb` utility methods.