### PR TITLE
Allow calling Rational#to_d without arguments

### DIFF
--- a/lib/bigdecimal/util.rb
+++ b/lib/bigdecimal/util.rb
@@ -119,8 +119,11 @@ class Rational < Numeric
   #
   # Returns the value as a BigDecimal.
   #
-  # The required +precision+ parameter is used to determine the number of
-  # significant digits for the result.
+  # The +precision+ parameter is used to determine the number of
+  # significant digits for the result. When +precision+ is set to +0+,
+  # the number of digits to represent the float being converted is determined
+  # automatically.
+  # The default +precision+ is +0+.
   #
   #     require 'bigdecimal'
   #     require 'bigdecimal/util'
@@ -129,7 +132,7 @@ class Rational < Numeric
   #
   # See also Kernel.BigDecimal.
   #
-  def to_d(precision)
+  def to_d(precision=0)
     BigDecimal(self, precision)
   end
 end
@@ -141,29 +144,27 @@ class Complex < Numeric
   #     cmp.to_d(precision)  -> bigdecimal
   #
   # Returns the value as a BigDecimal.
+  # If the imaginary part is not +0+, an error is raised
   #
-  # The +precision+ parameter is required for a rational complex number.
-  # This parameter is used to determine the number of significant digits
-  # for the result.
+  # The +precision+ parameter is used to determine the number of
+  # significant digits for the result. When +precision+ is set to +0+,
+  # the number of digits to represent the float being converted is determined
+  # automatically.
+  # The default +precision+ is +0+.
   #
   #     require 'bigdecimal'
   #     require 'bigdecimal/util'
   #
   #     Complex(0.1234567, 0).to_d(4)   # => 0.1235e0
   #     Complex(Rational(22, 7), 0).to_d(3)   # => 0.314e1
+  #     Complex(1, 1).to_d   # raises ArgumentError
   #
   # See also Kernel.BigDecimal.
   #
-  def to_d(*args)
+  def to_d(precision=0)
     BigDecimal(self) unless self.imag.zero? # to raise error
 
-    if args.length == 0
-      case self.real
-      when Rational
-        BigDecimal(self.real) # to raise error
-      end
-    end
-    self.real.to_d(*args)
+    BigDecimal(self.real, precision)
   end
 end
 

--- a/test/bigdecimal/test_bigdecimal_util.rb
+++ b/test/bigdecimal/test_bigdecimal_util.rb
@@ -84,6 +84,11 @@ class TestBigDecimalUtil < Test::Unit::TestCase
     assert(355.quo(113).to_d(digits).frozen?)
   end
 
+  def test_Rational_to_d_without_precision
+    assert_equal(BigDecimal("1.25"), Rational(5, 4).to_d)
+    assert_equal(BigDecimal(355.quo(113), 0), 355.quo(113).to_d)
+  end
+
   def test_Rational_to_d_with_zero_precision
     assert_equal(BigDecimal(355.quo(113), 0), 355.quo(113).to_d(0))
   end
@@ -102,7 +107,7 @@ class TestBigDecimalUtil < Test::Unit::TestCase
       assert_equal(BigDecimal("0.1234567"), Complex(0.1234567, 0).to_d)
       assert_equal(BigDecimal("0.1235"), Complex(0.1234567, 0).to_d(4))
 
-      assert_raise_with_message(ArgumentError, "can't omit precision for a Rational.") { Complex(1.quo(3), 0).to_d }
+      assert_equal(BigDecimal("0.5"), Complex(1.quo(2), 0).to_d)
 
       assert_raise_with_message(ArgumentError, "Unable to make a BigDecimal from non-zero imaginary number") { Complex(1, 1).to_d }
     end


### PR DESCRIPTION
Then the precision would be 0, just like with Float.


See https://github.com/ruby/bigdecimal/issues/276#issuecomment-2966635725