### PR TITLE
Change BigMath.sin and cos to always calculate in relative precision.

### DIFF
--- a/test/bigdecimal/helper.rb
+++ b/test/bigdecimal/helper.rb
@@ -40,25 +40,11 @@ module TestBigDecimalBase
   # Asserts that the calculation of the given block converges to some value
   # with precision specified by block parameter.
 
-  def assert_fixed_point_precision(&block)
-    _assert_precision(:fixed_point, &block)
-  end
-
   def assert_relative_precision(&block)
-    _assert_precision(:relative, &block)
-  end
-
-  def _assert_precision(mode)
     expected = yield(200)
     [50, 100, 150].each do |n|
       value = yield(n)
-      if mode == :fixed_point
-        precision = -(value - expected).exponent
-      elsif mode == :relative
-        precision = 1 - (value.div(expected, expected.precision) - 1).exponent
-      else
-        raise ArgumentError, "Unknown mode: #{mode}"
-      end
+      precision = 1 - (value.div(expected, expected.precision) - 1).exponent
       assert(value != expected, "Unable to estimate precision for exact value")
       assert(precision >= n, "Precision is not enough: #{precision} < #{n}")
     end

--- a/test/bigdecimal/test_bigmath.rb
+++ b/test/bigdecimal/test_bigmath.rb
@@ -59,11 +59,11 @@ class TestBigMath < Test::Unit::TestCase
     assert_in_delta(BigDecimal('0.5'), sin(PI(100) / 6, 100), BigDecimal("1e-100"))
     assert_in_delta(SQRT3 / 2, sin(PI(100) / 3, 100), BigDecimal("1e-100"))
     assert_in_delta(SQRT2 / 2, sin(PI(100) / 4, 100), BigDecimal("1e-100"))
-    assert_fixed_point_precision {|n| sin(BigDecimal("1"), n) }
-    assert_fixed_point_precision {|n| sin(BigDecimal("1e50"), n) }
-    assert_fixed_point_precision {|n| sin(BigDecimal("1e-30"), n) }
-    assert_fixed_point_precision {|n| sin(BigDecimal(PI(50)), n) }
-    assert_fixed_point_precision {|n| sin(BigDecimal(PI(50) * 100), n) }
+    assert_relative_precision {|n| sin(BigDecimal("1"), n) }
+    assert_relative_precision {|n| sin(BigDecimal("1e50"), n) }
+    assert_relative_precision {|n| sin(BigDecimal("1e-30"), n) }
+    assert_relative_precision {|n| sin(BigDecimal(PI(50)), n) }
+    assert_relative_precision {|n| sin(BigDecimal(PI(50) * 100), n) }
     assert_operator(sin(PI(30) / 2, 30), :<=, 1)
     assert_operator(sin(-PI(30) / 2, 30), :>=, -1)
   end
@@ -83,10 +83,10 @@ class TestBigMath < Test::Unit::TestCase
     assert_in_delta(BigDecimal('0.5'), cos(PI(100) / 3, 100), BigDecimal("1e-100"))
     assert_in_delta(SQRT3 / 2, cos(PI(100) / 6, 100), BigDecimal("1e-100"))
     assert_in_delta(SQRT2 / 2, cos(PI(100) / 4, 100), BigDecimal("1e-100"))
-    assert_fixed_point_precision {|n| cos(BigDecimal("1"), n) }
-    assert_fixed_point_precision {|n| cos(BigDecimal("1e50"), n) }
-    assert_fixed_point_precision {|n| cos(BigDecimal(PI(50) / 2), n) }
-    assert_fixed_point_precision {|n| cos(BigDecimal(PI(50) * 201 / 2), n) }
+    assert_relative_precision {|n| cos(BigDecimal("1"), n) }
+    assert_relative_precision {|n| cos(BigDecimal("1e50"), n) }
+    assert_relative_precision {|n| cos(BigDecimal(PI(50) / 2), n) }
+    assert_relative_precision {|n| cos(BigDecimal(PI(50) * 201 / 2), n) }
     assert_operator(cos(PI(30), 30), :>=, -1)
     assert_operator(cos(PI(30) * 2, 30), :<=, 1)
   end


### PR DESCRIPTION
Almost all methods in BigDecimal/BigMath that takes precision calculates in relative precision.
Only `BigMath.sin`(except x around 0) and `BigMath.cos`(always) was calculating in fixed-point precision.
There is no document that says sin and cos is fixed-point precision. It can be considered bug (or wrong document).

```ruby
BigMath.sin(BigDecimal('31.4159265358979323846264338327951111111111'), 30)
#=> 0.822691394060062514...e-31 (before, precision: 18)
#=> 0.822691394060062489417902505540769218359371379100137196517465784...e-31 (after)
#=> 0.82269139406006248941790250554076921835937137910013719651746578736517692e-31 (actual value)
```

### Other
- Implementing BigMath.tan needs relative precision version of sin and cos.
- BigMath.tan(x, prec) will calculate in relative precision in all `x` around `int * π / 2`, so if sin and cos is in fixed-point precision, it's not consistent.

