### PR TITLE
Rename assert_relative_precision to assert_converge_in_precision

### DIFF
--- a/test/bigdecimal/helper.rb
+++ b/test/bigdecimal/helper.rb
@@ -40,7 +40,7 @@ module TestBigDecimalBase
   # Asserts that the calculation of the given block converges to some value
   # with precision specified by block parameter.
 
-  def assert_relative_precision(&block)
+  def assert_converge_in_precision(&block)
     expected = yield(200)
     [50, 100, 150].each do |n|
       value = yield(n)

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -2011,21 +2011,21 @@ class TestBigDecimal < Test::Unit::TestCase
     y = BigDecimal("3.14159265358979323846264338327950288419716939937511")
     small = x * BigDecimal("1e-30")
     large = y * BigDecimal("1e+30")
-    assert_relative_precision {|n| small.power(small, n) }
-    assert_relative_precision {|n| large.power(small, n) }
-    assert_relative_precision {|n| x.power(small, n) }
-    assert_relative_precision {|n| small.power(y, n) }
-    assert_relative_precision {|n| small.power(small + 1, n) }
-    assert_relative_precision {|n| x.power(small + 1, n) }
-    assert_relative_precision {|n| (small + 1).power(small, n) }
-    assert_relative_precision {|n| (small + 1).power(large, n) }
-    assert_relative_precision {|n| (small + 1).power(y, n) }
-    assert_relative_precision {|n| x.power(y, n) }
-    assert_relative_precision {|n| x.power(-y, n) }
-    assert_relative_precision {|n| x.power(123, n) }
-    assert_relative_precision {|n| x.power(-456, n) }
-    assert_relative_precision {|n| (x + 12).power(y + 34, n) }
-    assert_relative_precision {|n| (x + 56).power(y - 78, n) }
+    assert_converge_in_precision {|n| small.power(small, n) }
+    assert_converge_in_precision {|n| large.power(small, n) }
+    assert_converge_in_precision {|n| x.power(small, n) }
+    assert_converge_in_precision {|n| small.power(y, n) }
+    assert_converge_in_precision {|n| small.power(small + 1, n) }
+    assert_converge_in_precision {|n| x.power(small + 1, n) }
+    assert_converge_in_precision {|n| (small + 1).power(small, n) }
+    assert_converge_in_precision {|n| (small + 1).power(large, n) }
+    assert_converge_in_precision {|n| (small + 1).power(y, n) }
+    assert_converge_in_precision {|n| x.power(y, n) }
+    assert_converge_in_precision {|n| x.power(-y, n) }
+    assert_converge_in_precision {|n| x.power(123, n) }
+    assert_converge_in_precision {|n| x.power(-456, n) }
+    assert_converge_in_precision {|n| (x + 12).power(y + 34, n) }
+    assert_converge_in_precision {|n| (x + 56).power(y - 78, n) }
   end
 
   def test_limit

--- a/test/bigdecimal/test_bigmath.rb
+++ b/test/bigdecimal/test_bigmath.rb
@@ -18,7 +18,7 @@ class TestBigMath < Test::Unit::TestCase
       BigDecimal("3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068"),
       PI(100).round(100)
     )
-    assert_relative_precision {|n| PI(n) }
+    assert_converge_in_precision {|n| PI(n) }
   end
 
   def test_e
@@ -26,7 +26,7 @@ class TestBigMath < Test::Unit::TestCase
       BigDecimal("2.718281828459045235360287471352662497757247093699959574966967627724076630353547594571382178525166427"),
       E(100)
     )
-    assert_relative_precision {|n| E(n) }
+    assert_converge_in_precision {|n| E(n) }
   end
 
   def test_sqrt
@@ -39,9 +39,9 @@ class TestBigMath < Test::Unit::TestCase
     assert_raise(FloatDomainError) {sqrt(PINF, N)}
     assert_in_delta(SQRT2, sqrt(BigDecimal("2"), 100), BigDecimal("1e-100"))
     assert_in_delta(SQRT3, sqrt(BigDecimal("3"), 100), BigDecimal("1e-100"))
-    assert_relative_precision {|n| sqrt(BigDecimal("2"), n) }
-    assert_relative_precision {|n| sqrt(BigDecimal("2e-50"), n) }
-    assert_relative_precision {|n| sqrt(BigDecimal("2e50"), n) }
+    assert_converge_in_precision {|n| sqrt(BigDecimal("2"), n) }
+    assert_converge_in_precision {|n| sqrt(BigDecimal("2e-50"), n) }
+    assert_converge_in_precision {|n| sqrt(BigDecimal("2e50"), n) }
   end
 
   def test_sin
@@ -59,11 +59,11 @@ class TestBigMath < Test::Unit::TestCase
     assert_in_delta(BigDecimal('0.5'), sin(PI(100) / 6, 100), BigDecimal("1e-100"))
     assert_in_delta(SQRT3 / 2, sin(PI(100) / 3, 100), BigDecimal("1e-100"))
     assert_in_delta(SQRT2 / 2, sin(PI(100) / 4, 100), BigDecimal("1e-100"))
-    assert_relative_precision {|n| sin(BigDecimal("1"), n) }
-    assert_relative_precision {|n| sin(BigDecimal("1e50"), n) }
-    assert_relative_precision {|n| sin(BigDecimal("1e-30"), n) }
-    assert_relative_precision {|n| sin(BigDecimal(PI(50)), n) }
-    assert_relative_precision {|n| sin(BigDecimal(PI(50) * 100), n) }
+    assert_converge_in_precision {|n| sin(BigDecimal("1"), n) }
+    assert_converge_in_precision {|n| sin(BigDecimal("1e50"), n) }
+    assert_converge_in_precision {|n| sin(BigDecimal("1e-30"), n) }
+    assert_converge_in_precision {|n| sin(BigDecimal(PI(50)), n) }
+    assert_converge_in_precision {|n| sin(BigDecimal(PI(50) * 100), n) }
     assert_operator(sin(PI(30) / 2, 30), :<=, 1)
     assert_operator(sin(-PI(30) / 2, 30), :>=, -1)
   end
@@ -83,10 +83,10 @@ class TestBigMath < Test::Unit::TestCase
     assert_in_delta(BigDecimal('0.5'), cos(PI(100) / 3, 100), BigDecimal("1e-100"))
     assert_in_delta(SQRT3 / 2, cos(PI(100) / 6, 100), BigDecimal("1e-100"))
     assert_in_delta(SQRT2 / 2, cos(PI(100) / 4, 100), BigDecimal("1e-100"))
-    assert_relative_precision {|n| cos(BigDecimal("1"), n) }
-    assert_relative_precision {|n| cos(BigDecimal("1e50"), n) }
-    assert_relative_precision {|n| cos(BigDecimal(PI(50) / 2), n) }
-    assert_relative_precision {|n| cos(BigDecimal(PI(50) * 201 / 2), n) }
+    assert_converge_in_precision {|n| cos(BigDecimal("1"), n) }
+    assert_converge_in_precision {|n| cos(BigDecimal("1e50"), n) }
+    assert_converge_in_precision {|n| cos(BigDecimal(PI(50) / 2), n) }
+    assert_converge_in_precision {|n| cos(BigDecimal(PI(50) * 201 / 2), n) }
     assert_operator(cos(PI(30), 30), :>=, -1)
     assert_operator(cos(PI(30) * 2, 30), :<=, 1)
   end
@@ -99,9 +99,9 @@ class TestBigMath < Test::Unit::TestCase
     assert_in_delta(PI(100) / 3, atan(SQRT3, 100), BigDecimal("1e-100"))
     assert_equal(BigDecimal("0.823840753418636291769355073102514088959345624027952954058347023122539489"),
                  atan(BigDecimal("1.08"), 72).round(72), '[ruby-dev:41257]')
-    assert_relative_precision {|n| atan(BigDecimal("2"), n)}
-    assert_relative_precision {|n| atan(BigDecimal("1e-30"), n)}
-    assert_relative_precision {|n| atan(BigDecimal("1e30"), n)}
+    assert_converge_in_precision {|n| atan(BigDecimal("2"), n)}
+    assert_converge_in_precision {|n| atan(BigDecimal("1e-30"), n)}
+    assert_converge_in_precision {|n| atan(BigDecimal("1e30"), n)}
   end
 
   def test_exp
@@ -111,11 +111,11 @@ class TestBigMath < Test::Unit::TestCase
     assert_equal(1, BigMath.exp(BigDecimal("0"), N))
     assert_in_epsilon(BigDecimal("4.48168907033806482260205546011927581900574986836966705677265008278593667446671377298105383138245339138861635065183019577"),
                       BigMath.exp(BigDecimal("1.5"), 100), BigDecimal("1e-100"))
-    assert_relative_precision {|n| BigMath.exp(BigDecimal("1"), n) }
-    assert_relative_precision {|n| BigMath.exp(BigDecimal("-2"), n) }
-    assert_relative_precision {|n| BigMath.exp(BigDecimal("-34"), n) }
-    assert_relative_precision {|n| BigMath.exp(BigDecimal("567"), n) }
-    assert_relative_precision {|n| BigMath.exp(SQRT2, n) }
+    assert_converge_in_precision {|n| BigMath.exp(BigDecimal("1"), n) }
+    assert_converge_in_precision {|n| BigMath.exp(BigDecimal("-2"), n) }
+    assert_converge_in_precision {|n| BigMath.exp(BigDecimal("-34"), n) }
+    assert_converge_in_precision {|n| BigMath.exp(BigDecimal("567"), n) }
+    assert_converge_in_precision {|n| BigMath.exp(SQRT2, n) }
   end
 
   def test_log
@@ -123,11 +123,11 @@ class TestBigMath < Test::Unit::TestCase
     assert_in_epsilon(Math.log(10)*1000, BigMath.log(BigDecimal("1e1000"), 10))
     assert_in_epsilon(BigDecimal("2.3025850929940456840179914546843642076011014886287729760333279009675726096773524802359972050895982983419677840422862"),
                       BigMath.log(BigDecimal("10"), 100), BigDecimal("1e-100"))
-    assert_relative_precision {|n| BigMath.log(BigDecimal("2"), n) }
-    assert_relative_precision {|n| BigMath.log(BigDecimal("1e-30") + 1, n) }
-    assert_relative_precision {|n| BigMath.log(BigDecimal("1e-30"), n) }
-    assert_relative_precision {|n| BigMath.log(BigDecimal("1e30"), n) }
-    assert_relative_precision {|n| BigMath.log(SQRT2, n) }
+    assert_converge_in_precision {|n| BigMath.log(BigDecimal("2"), n) }
+    assert_converge_in_precision {|n| BigMath.log(BigDecimal("1e-30") + 1, n) }
+    assert_converge_in_precision {|n| BigMath.log(BigDecimal("1e-30"), n) }
+    assert_converge_in_precision {|n| BigMath.log(BigDecimal("1e30"), n) }
+    assert_converge_in_precision {|n| BigMath.log(SQRT2, n) }
     assert_raise(Math::DomainError) {BigMath.log(BigDecimal("0"), 10)}
     assert_raise(Math::DomainError) {BigMath.log(BigDecimal("-1"), 10)}
     assert_separately(%w[-rbigdecimal], <<-SRC)


### PR DESCRIPTION
Now that assert_fixed_point_precision is removed and there is only assert_relative_precision, "relative" part is not important anymore. Change it to `assert_converge_in_precision` which express the assertion more accurate.
