### PR TITLE
Make internal BigMath method a private method

### DIFF
--- a/lib/bigdecimal/math.rb
+++ b/lib/bigdecimal/math.rb
@@ -51,7 +51,7 @@ module BigMath
   # and satisfies sin(x) = sign * sin(reduced_x)
   # If add_half_pi is true, adds pi/2 to x before reduction.
   # Precision of pi is adjusted to ensure reduced_x has the required precision.
-  private def _sin_periodic_reduction(x, prec, add_half_pi: false)
+  private_class_method def _sin_periodic_reduction(x, prec, add_half_pi: false) # :nodoc:
     return [1, x] if -Math::PI/2 <= x && x <= Math::PI/2 && !add_half_pi
 
     mod_prec = prec + BigDecimal.double_fig


### PR DESCRIPTION
`private def` has no effect in BigMath module. Change it to `private_class_method`

```ruby
module BigMath
  module_function

  # Private BigMath#foo and public BigMath.foo
  def foo; end 

  # Same as above. private has no effect
  private def foo; end

  # Private BigMath#foo and private BigMath.foo
  private_class_method def foo; end
end
```