### PR TITLE
Bumb version to 3.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,27 @@
 # CHANGES
 
+## 3.3.0
+
+* Allow calling to_d without arguments [GH-421]
+
+  **@fsateler**
+
+* Calculate BigMath.sin and cos in relative precision [GH-422]
+
+  **@tompng**
+
+* Add support for tangent function [GH-231]
+
+  **@rhannequin**
+
+* BigMath methods accepts numeric as an argument [GH-415]
+
+  **@tompng**
+
+* Round result of sqrt and BigMath methods [GH-427]
+
+  **@tompng**
+
 ## 3.2.3
 
 * Allow BigDecimal accept Float without precision [GH-314]

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -31,7 +31,7 @@
 #include "bits.h"
 #include "static_assert.h"
 
-#define BIGDECIMAL_VERSION "3.2.3"
+#define BIGDECIMAL_VERSION "3.3.0"
 
 /* #define ENABLE_NUMERIC_STRING */
 


### PR DESCRIPTION
New feature:
- `BigMath.tan(x, prec)`
- `BigMath.sin`, `cos`, `tan`, `atan`, `exp`, `log`, `sqrt` accepts numeric
- `to_d` without precision is always allowed

https://github.com/ruby/bigdecimal/compare/v3.2.3...cb2458bde33bf90a8364b58d53e8948a7ba555ea
