### PR TITLE
Improve performance of x**y when y is a huge value

### DIFF
--- a/lib/bigdecimal.rb
+++ b/lib/bigdecimal.rb
@@ -165,20 +165,32 @@ class BigDecimal
       return BigDecimal(1).div(inv, prec)
     end
 
-    int_part = y.fix.to_i
-    prec2 = prec + BigDecimal.double_fig
-    pow_prec = prec2 + (int_part > 0 ? y.exponent : 0)
-    ans = BigDecimal(1)
-    n = 1
-    xn = x
-    while true
-      ans = ans.mult(xn, pow_prec) if int_part.allbits?(n)
-      n <<= 1
-      break if n > int_part
-      xn = xn.mult(xn, pow_prec)
+    if y.exponent > Math.log(prec) * 5 + 20
+      # x**int_part calculation is slow when y.exponent is large, so skip it
+      int_part = 0
+      rest_part = y
+    else
+      int_part = y.fix.to_i
+      rest_part = frac_part
     end
-    unless frac_part.zero?
-      ans = ans.mult(BigMath.exp(BigMath.log(x, prec2).mult(frac_part, prec2), prec2), prec2)
+
+    prec2 = prec + BigDecimal.double_fig
+    ans = BigDecimal(1)
+
+    if int_part > 0
+      pow_prec = prec2 + y.exponent
+      n = 1
+      xn = x
+      while true
+        ans = ans.mult(xn, pow_prec) if int_part.allbits?(n)
+        n <<= 1
+        break if n > int_part
+        xn = xn.mult(xn, pow_prec)
+      end
+    end
+
+    unless rest_part.zero?
+      ans = ans.mult(BigMath.exp(BigMath.log(x, prec2).mult(rest_part, prec2), prec2), prec2)
     end
     ans.mult(1, prec)
   end

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1991,6 +1991,11 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_in_epsilon(z2, x2 ** y, 1e-99)
   end
 
+  def test_power_with_huge_value
+    n = BigDecimal('7e+10000')
+    assert_equal(BigMath.exp(1, 100), (1 + BigDecimal(1).div(n, 120)).power(n, 100))
+  end
+
   def test_power_precision
     x = BigDecimal("1.41421356237309504880168872420969807856967187537695")
     y = BigDecimal("3.14159265358979323846264338327950288419716939937511")


### PR DESCRIPTION
When y.exponent is several thousand or more, `x**y` was slow because repeated squaring algorithm requires several thousands of multiplications. Skip repeated squaring in such case.

```
irb(main):002> n=BigDecimal('1e+4000'); (1+1/n).power(n, 100)
processing time: 14.743024s => 0.003061s
=> 0.2718281828459045235360287471352662497757247093699959574966967627724076630353547594571382178525166427e1
```

Diff is basically just adding this condition (plus adding indent, guard and variable rename)
```ruby
if y.exponent > Math.log(prec) * 5 + 20
  int_part = 0
  frac_part = y
end
```
Appropriate threshold of `y.exponent` depends on exp, log, and multiplication performance.
This condition is tuned with `prec <= 1000000` and #407 #433 applied.
Theoretically, the condition should be `y.exponent > coef * log(prec)**a` where a is between `1..3`, I guess.
