### PR TITLE
Unify all precision validation to be consistent with BigDecimal#add

### DIFF
--- a/lib/bigdecimal/math.rb
+++ b/lib/bigdecimal/math.rb
@@ -41,7 +41,7 @@ module BigMath
   #   #=> "0.14142135623730950488016887242097e1"
   #
   def sqrt(x, prec)
-    BigDecimal::Internal.validate_prec(prec, :sqrt)
+    prec = BigDecimal::Internal.coerce_validate_prec(prec, :sqrt)
     x = BigDecimal::Internal.coerce_to_bigdecimal(x, prec, :sqrt)
     x.sqrt(prec)
   end
@@ -85,7 +85,7 @@ module BigMath
   #   #=> "0.70710807985947359435812921837984e0"
   #
   def sin(x, prec)
-    BigDecimal::Internal.validate_prec(prec, :sin)
+    prec = BigDecimal::Internal.coerce_validate_prec(prec, :sin)
     x = BigDecimal::Internal.coerce_to_bigdecimal(x, prec, :sin)
     return BigDecimal::Internal.nan_computation_result if x.infinite? || x.nan?
     n    = prec + BigDecimal.double_fig
@@ -122,7 +122,7 @@ module BigMath
   #   #=> "-0.99999999999999999999999999999997e0"
   #
   def cos(x, prec)
-    BigDecimal::Internal.validate_prec(prec, :cos)
+    prec = BigDecimal::Internal.coerce_validate_prec(prec, :cos)
     x = BigDecimal::Internal.coerce_to_bigdecimal(x, prec, :cos)
     return BigDecimal::Internal.nan_computation_result if x.infinite? || x.nan?
     sign, x = _sin_periodic_reduction(x, prec + BigDecimal.double_fig, add_half_pi: true)
@@ -144,7 +144,7 @@ module BigMath
   #   #=> "0.99999999999999999999999830836025e0"
   #
   def tan(x, prec)
-    BigDecimal::Internal.validate_prec(prec, :tan)
+    prec = BigDecimal::Internal.coerce_validate_prec(prec, :tan)
     sin(x, prec + BigDecimal.double_fig).div(cos(x, prec + BigDecimal.double_fig), prec)
   end
 
@@ -160,7 +160,7 @@ module BigMath
   #   #=> "-0.78539816339744830961566084581988e0"
   #
   def atan(x, prec)
-    BigDecimal::Internal.validate_prec(prec, :atan)
+    prec = BigDecimal::Internal.coerce_validate_prec(prec, :atan)
     x = BigDecimal::Internal.coerce_to_bigdecimal(x, prec, :atan)
     return BigDecimal::Internal.nan_computation_result if x.nan?
     n = prec + BigDecimal.double_fig
@@ -198,7 +198,7 @@ module BigMath
   #   #=> "0.31415926535897932384626433832795e1"
   #
   def PI(prec)
-    BigDecimal::Internal.validate_prec(prec, :PI)
+    prec = BigDecimal::Internal.coerce_validate_prec(prec, :PI)
     n      = prec + BigDecimal.double_fig
     zero   = BigDecimal("0")
     one    = BigDecimal("1")
@@ -243,7 +243,7 @@ module BigMath
   #   #=> "0.27182818284590452353602874713527e1"
   #
   def E(prec)
-    BigDecimal::Internal.validate_prec(prec, :E)
+    prec = BigDecimal::Internal.coerce_validate_prec(prec, :E)
     BigMath.exp(1, prec)
   end
 end

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1813,6 +1813,10 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_power_with_intger_infinite_precision
     assert_equal(1234 ** 100, (BigDecimal("12.34") ** 100) * BigDecimal("1e200"))
     assert_in_delta(1234 ** 100, 1 / (BigDecimal("12.34") ** -100) * BigDecimal("1e200"), 1)
+    BigDecimal.save_limit do
+      BigDecimal.limit 10
+      assert_equal(BigDecimal("0.1353679867e110"), BigDecimal("12.34") ** 100)
+    end
   end
 
   def test_power_with_BigDecimal
@@ -2351,18 +2355,6 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_BigMath_log_with_nil
     assert_raise(ArgumentError) do
       BigMath.log(nil, 20)
-    end
-  end
-
-  def test_BigMath_log_with_non_integer_precision
-    assert_raise(ArgumentError) do
-      BigMath.log(1, 0.5)
-    end
-  end
-
-  def test_BigMath_log_with_nil_precision
-    assert_raise(ArgumentError) do
-      BigMath.log(1, nil)
     end
   end
 


### PR DESCRIPTION
BigMath methods was aligned with BigMath.log precision handling that raises "precision must be an Integer" for non-integers.
This is different from BigDecimal#add handling that converts with to_int. This commit unifies all precision handling to match BigDecimal#add series.

In addition, bigdecimal tests in ruby/spec requires non-integer precision to be accepted.

Round (BigDecimal and Float) also accepts non-integer ndigits
```ruby
1.23456789.round(3.5) #=> 1.235
BigDecimal(1.23456789).round(3.5) #=> 0.1235e1
```