### PR TITLE
Fix x**y, x.power(y, 0) and x.sqrt(0) calculates huge digits if precision limit is huge

### DIFF
--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -2072,14 +2072,17 @@ class TestBigDecimal < Test::Unit::TestCase
       assert_equal(BigDecimal('0.889'), (BigDecimal('0.8888') - BigDecimal('0')))
       assert_equal(BigDecimal('2.66'), (BigDecimal('0.888') * BigDecimal('3')))
       assert_equal(BigDecimal('0.296'), (BigDecimal('0.8888') / BigDecimal('3')))
+      assert_equal(BigDecimal('0.222e109'), BigDecimal('98.76') ** BigDecimal('54.32'))
       assert_equal(BigDecimal('0.889'), BigDecimal('0.8888').add(BigDecimal('0'), 0))
       assert_equal(BigDecimal('0.889'), BigDecimal('0.8888').sub(BigDecimal('0'), 0))
       assert_equal(BigDecimal('2.66'), BigDecimal('0.888').mult(BigDecimal('3'), 0))
       assert_equal(BigDecimal('0.296'), BigDecimal('0.8888').div(BigDecimal('3'), 0))
+      assert_equal(BigDecimal('0.222e109'), BigDecimal('98.76').power(BigDecimal('54.32'), 0))
       assert_equal(BigDecimal('0.8888'), BigDecimal('0.8888').add(BigDecimal('0'), 5))
       assert_equal(BigDecimal('0.8888'), BigDecimal('0.8888').sub(BigDecimal('0'), 5))
       assert_equal(BigDecimal('2.664'), BigDecimal('0.888').mult(BigDecimal('3'), 5))
       assert_equal(BigDecimal('0.29627'), BigDecimal('0.8888').div(BigDecimal('3'), 5))
+      assert_equal(BigDecimal('0.22164e109'), BigDecimal('98.76').power(BigDecimal('54.32'), 5))
     end
   end
 
@@ -2089,6 +2092,26 @@ class TestBigDecimal < Test::Unit::TestCase
       div = x / y
       BigDecimal.limit(1000)
       assert_equal(div, x / y)
+    end
+  end
+
+  def test_sqrt_with_huge_limit
+    BigDecimal.save_limit do
+      x = BigDecimal("12.34")
+      sqrt = x.sqrt(0)
+      BigDecimal.limit(1000)
+      assert_equal(sqrt, x.sqrt(0))
+    end
+  end
+
+def test_power_with_huge_limit
+    BigDecimal.save_limit do
+      x = BigDecimal("12.34")
+      y = BigDecimal("56.78")
+      pow = x ** y
+      BigDecimal.limit(1000)
+      assert_equal(pow, x ** y)
+      assert_equal(pow, x.power(y, 0))
     end
   end
 


### PR DESCRIPTION
Fix this bug
```ruby
BigDecimal.limit 1000
BigDecimal(2) / 3
#=> 0.66666666666666666666666666666667e0
BigDecimal(0.111111111).sqrt(0)
#=> 0.3333333331666666666249999999791666666536...(1000 digits, too long)
BigDecimal(2) ** 1.2
#=> 0.229739670999407001359725389355585517888...(1000 digits, too long)
```

Limit is just a limit. It's just a maximum precision restriction when precision is omitted. It's not a default precision value.

Expected behavior is:
```ruby
# When `limit < auto_determined_precision`
BigDecimal.limit 10
BigDecimal(2) / 3
#=> 0.6666666667e0
BigDecimal(0.111111111).sqrt(0)
#=> 0.3333333332e0
BigDecimal(2) ** 1.2
#=> 0.229739671e1

# When no limit or `limit > auto_determined_precision`
BigDecimal.limit 0
BigDecimal(2) / 3
#=> 0.66666666666666666666666666666667e0
BigDecimal(0.111111111).sqrt(0)
#=> 0.333333333166666666625e0
BigDecimal(2) ** 1.2
#=> 0.22973967099940700135972538935559e1
```
