### PR TITLE
Fix fast-path of frac and _decimal_shift affected by BigDecimal.limit

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2507,7 +2507,7 @@ BigDecimal_decimal_shift(VALUE self, VALUE v)
     prec = a.real->Prec + shiftDown;
     c = NewZeroWrap(1, prec * BASE_FIG);
     if (shift == 0) {
-        VpAsgn(c.real, a.real, 1);
+        VpAsgn(c.real, a.real, 10);
     } else if (shiftDown) {
         DECDIG carry = 0;
         exponentShift++;
@@ -6166,7 +6166,7 @@ VpFrac(Real *y, Real *x)
     size_t my, ind_y, ind_x;
 
     if (!VpHasVal(x)) {
-	VpAsgn(y, x, 1);
+	VpAsgn(y, x, 10);
 	goto Exit;
     }
 
@@ -6175,7 +6175,7 @@ VpFrac(Real *y, Real *x)
 	goto Exit;
     }
     else if (x->exponent <= 0) {
-	VpAsgn(y, x, 1);
+	VpAsgn(y, x, 10);
 	goto Exit;
     }
 

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -1440,6 +1440,11 @@ class TestBigDecimal < Test::Unit::TestCase
         assert_equal(num / 10**shift, num._decimal_shift(-shift))
       end
     end
+    BigDecimal.save_limit do
+      BigDecimal.limit(3)
+      assert_equal(BigDecimal('123456789e4'), BigDecimal('123456789')._decimal_shift(4))
+      assert_equal(BigDecimal('123456789e9'), BigDecimal('123456789')._decimal_shift(9))
+    end
   end
 
   def test_fix
@@ -1454,6 +1459,11 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(0.1, BigDecimal("0.1").frac)
     BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
     assert_nan(BigDecimal("NaN").frac)
+    BigDecimal.save_limit do
+      BigDecimal.limit(3)
+      assert_equal(BigDecimal('0.456789'), BigDecimal('123.456789').frac)
+      assert_equal(BigDecimal('0.0123456789'), BigDecimal('0.0123456789').frac)
+    end
   end
 
   def test_round


### PR DESCRIPTION
Fixes these bugs
```ruby
BigDecimal.limit 3

BigDecimal(123456789)._decimal_shift(9)
=> 0.123e18 # should be 0.123456789e18

BigDecimal(0.0123456789).frac
=> 0.123e-1 # should be 0.123456789e-1
```

Suppress rounding in
Fast-path of _decimal_shift: shift is a multiple of BASE_FIG
Fast-path of frac: fix part is zero
