### PR TITLE
Update the latest versions of actions

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -31,16 +31,16 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@13e7a03dc3ac6c3798f4570bfead2aed4d96abfb # v1.244.0
+        uses: ruby/setup-ruby@d5126b9b3579e429dd52e51e68624dda2e05be25 # v1.267.0
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
 
       - name: Publish to RubyGems
-        uses: rubygems/release-gem@a25424ba2ba8b387abc8ef40807c2c85b96cbe32 # v1.1.1
+        uses: rubygems/release-gem@1c162a739e8b4cb21a676e97b087e8268d8fc40b # v1.1.2
 
       - name: Create GitHub release
         run: |


### PR DESCRIPTION
We need to update release-gem-1.1.2 to use sigstore. And I update other actions to the latest versions.

I'm not sure why dependabot is not working with this repo.