### PR TITLE
Make BigMath.exp and log also a module_method

### DIFF
--- a/lib/bigdecimal.rb
+++ b/lib/bigdecimal.rb
@@ -238,6 +238,7 @@ end
 # Core BigMath methods for BigDecimal (log, exp) are defined here.
 # Other methods (sin, cos, atan) are defined in 'bigdecimal/math.rb'.
 module BigMath
+  module_function
 
   # call-seq:
   #   BigMath.log(decimal, numeric)    -> BigDecimal
@@ -251,7 +252,7 @@ module BigMath
   #
   # If +decimal+ is NaN, returns NaN.
   #
-  def self.log(x, prec)
+  def log(x, prec)
     prec = BigDecimal::Internal.coerce_validate_prec(prec, :log)
     raise Math::DomainError, 'Complex argument for BigMath.log' if Complex === x
 
@@ -306,7 +307,7 @@ module BigMath
   end
 
   # Taylor series for exp(x) around 0
-  private_class_method def self._exp_taylor(x, prec) # :nodoc:
+  private_class_method def _exp_taylor(x, prec) # :nodoc:
     xn = BigDecimal(1)
     y = BigDecimal(1)
     1.step do |i|
@@ -328,7 +329,7 @@ module BigMath
   #
   # If +decimal+ is NaN, returns NaN.
   #
-  def self.exp(x, prec)
+  def exp(x, prec)
     prec = BigDecimal::Internal.coerce_validate_prec(prec, :exp)
     x = BigDecimal::Internal.coerce_to_bigdecimal(x, prec, :exp)
     return BigDecimal::Internal.nan_computation_result if x.nan?

--- a/lib/bigdecimal/math.rb
+++ b/lib/bigdecimal/math.rb
@@ -355,7 +355,7 @@ module BigMath
 
     prec2 = prec + BigDecimal.double_fig
     prec2 -= x.exponent if x.exponent < 0
-    e = BigMath.exp(x, prec2)
+    e = exp(x, prec2)
     (e - BigDecimal(1).div(e, prec2)).div(2, prec)
   end
 
@@ -377,7 +377,7 @@ module BigMath
     return BigDecimal::Internal.infinity_computation_result if x.infinite?
 
     prec2 = prec + BigDecimal.double_fig
-    e = BigMath.exp(x, prec2)
+    e = exp(x, prec2)
     (e + BigDecimal(1).div(e, prec2)).div(2, prec)
   end
 
@@ -399,7 +399,7 @@ module BigMath
     return BigDecimal(x.infinite?) if x.infinite?
 
     prec2 = prec + BigDecimal.double_fig + [-x.exponent, 0].max
-    e = BigMath.exp(x, prec2)
+    e = exp(x, prec2)
     einv = BigDecimal(1).div(e, prec2)
     (e - einv).div(e + einv, prec)
   end
@@ -423,7 +423,7 @@ module BigMath
     return -asinh(-x, prec) if x < 0
 
     sqrt_prec = prec + [-x.exponent, 0].max + BigDecimal.double_fig
-    BigMath.log(x + sqrt(x**2 + 1, sqrt_prec), prec)
+    log(x + sqrt(x**2 + 1, sqrt_prec), prec)
   end
 
   # call-seq:
@@ -444,7 +444,7 @@ module BigMath
     return BigDecimal::Internal.infinity_computation_result if x.infinite?
     return BigDecimal::Internal.nan_computation_result if x.nan?
 
-    BigMath.log(x + sqrt(x**2 - 1, prec + BigDecimal.double_fig), prec)
+    log(x + sqrt(x**2 - 1, prec + BigDecimal.double_fig), prec)
   end
 
   # call-seq:
@@ -467,7 +467,7 @@ module BigMath
     return -BigDecimal::Internal.infinity_computation_result if x == -1
 
     prec2 = prec + BigDecimal.double_fig
-    (BigMath.log(x + 1, prec2) - BigMath.log(1 - x, prec2)).div(2, prec)
+    (log(x + 1, prec2) - log(1 - x, prec2)).div(2, prec)
   end
 
   # call-seq:
@@ -492,7 +492,7 @@ module BigMath
     return BigDecimal::Internal.infinity_computation_result if x.infinite? == 1
 
     prec2 = prec + BigDecimal.double_fig * 3 / 2
-    v = BigMath.log(x, prec2).div(BigMath.log(BigDecimal(2), prec2), prec2)
+    v = log(x, prec2).div(log(BigDecimal(2), prec2), prec2)
     # Perform half-up rounding to calculate log2(2**n)==n correctly in every rounding mode
     v = v.round(prec + BigDecimal.double_fig - (v.exponent < 0 ? v.exponent : 0), BigDecimal::ROUND_HALF_UP)
     v.mult(1, prec)
@@ -520,7 +520,7 @@ module BigMath
     return BigDecimal::Internal.infinity_computation_result if x.infinite? == 1
 
     prec2 = prec + BigDecimal.double_fig * 3 / 2
-    v = BigMath.log(x, prec2).div(BigMath.log(BigDecimal(10), prec2), prec2)
+    v = log(x, prec2).div(log(BigDecimal(10), prec2), prec2)
     # Perform half-up rounding to calculate log10(10**n)==n correctly in every rounding mode
     v = v.round(prec + BigDecimal.double_fig - (v.exponent < 0 ? v.exponent : 0), BigDecimal::ROUND_HALF_UP)
     v.mult(1, prec)
@@ -539,7 +539,7 @@ module BigMath
     x = BigDecimal::Internal.coerce_to_bigdecimal(x, prec, :log1p)
     raise Math::DomainError, 'Out of domain argument for log1p' if x < -1
 
-    return BigMath.log(x + 1, prec)
+    return log(x + 1, prec)
   end
 
   # call-seq:
@@ -565,7 +565,7 @@ module BigMath
     else
       exp_prec = prec
     end
-    exp_prec > 0 ? BigMath.exp(x, exp_prec).sub(1, prec) : BigDecimal(-1)
+    exp_prec > 0 ? exp(x, exp_prec).sub(1, prec) : BigDecimal(-1)
   end
 
 
@@ -625,6 +625,6 @@ module BigMath
   #
   def E(prec)
     prec = BigDecimal::Internal.coerce_validate_prec(prec, :E)
-    BigMath.exp(1, prec)
+    exp(1, prec)
   end
 end

--- a/test/bigdecimal/test_bigmath.rb
+++ b/test/bigdecimal/test_bigmath.rb
@@ -90,8 +90,8 @@ class TestBigMath < Test::Unit::TestCase
   def test_coerce_argument
     f = 0.8
     bd = BigDecimal(f)
-    assert_equal(BigMath.exp(bd, N), BigMath.exp(f, N))
-    assert_equal(BigMath.log(bd, N), BigMath.log(f, N))
+    assert_equal(exp(bd, N), exp(f, N))
+    assert_equal(log(bd, N), log(f, N))
     assert_equal(sqrt(bd, N), sqrt(f, N))
     assert_equal(cbrt(bd, N), cbrt(f, N))
     assert_equal(hypot(bd, bd, N), hypot(f, f, N))
@@ -371,35 +371,35 @@ class TestBigMath < Test::Unit::TestCase
 
   def test_exp
     [-100, -2, 0.5, 10, 100].each do |x|
-      assert_in_epsilon(Math.exp(x), BigMath.exp(BigDecimal(x, 0), N))
+      assert_in_epsilon(Math.exp(x), exp(BigDecimal(x, 0), N))
     end
-    assert_equal(1, BigMath.exp(BigDecimal("0"), N))
+    assert_equal(1, exp(BigDecimal("0"), N))
     assert_in_exact_precision(
       BigDecimal("4.48168907033806482260205546011927581900574986836966705677265008278593667446671377298105383138245339138861635065183019577"),
-      BigMath.exp(BigDecimal("1.5"), 100),
+      exp(BigDecimal("1.5"), 100),
       100
     )
-    assert_converge_in_precision {|n| BigMath.exp(BigDecimal("1"), n) }
-    assert_converge_in_precision {|n| BigMath.exp(BigDecimal("-2"), n) }
-    assert_converge_in_precision {|n| BigMath.exp(BigDecimal("-34"), n) }
-    assert_converge_in_precision {|n| BigMath.exp(BigDecimal("567"), n) }
-    assert_converge_in_precision {|n| BigMath.exp(SQRT2, n) }
+    assert_converge_in_precision {|n| exp(BigDecimal("1"), n) }
+    assert_converge_in_precision {|n| exp(BigDecimal("-2"), n) }
+    assert_converge_in_precision {|n| exp(BigDecimal("-34"), n) }
+    assert_converge_in_precision {|n| exp(BigDecimal("567"), n) }
+    assert_converge_in_precision {|n| exp(SQRT2, n) }
   end
 
   def test_log
-    assert_equal(0, BigMath.log(BigDecimal("1.0"), 10))
-    assert_in_epsilon(Math.log(10)*1000, BigMath.log(BigDecimal("1e1000"), 10))
+    assert_equal(0, log(BigDecimal("1.0"), 10))
+    assert_in_epsilon(Math.log(10)*1000, log(BigDecimal("1e1000"), 10))
     assert_in_exact_precision(
       BigDecimal("2.3025850929940456840179914546843642076011014886287729760333279009675726096773524802359972050895982983419677840422862"),
-      BigMath.log(BigDecimal("10"), 100),
+      log(BigDecimal("10"), 100),
       100
     )
-    assert_converge_in_precision {|n| BigMath.log(BigDecimal("2"), n) }
-    assert_converge_in_precision {|n| BigMath.log(BigDecimal("1e-30") + 1, n) }
-    assert_converge_in_precision {|n| BigMath.log(BigDecimal("1e-30"), n) }
-    assert_converge_in_precision {|n| BigMath.log(BigDecimal("1e30"), n) }
-    assert_converge_in_precision {|n| BigMath.log(SQRT2, n) }
-    assert_raise(Math::DomainError) {BigMath.log(BigDecimal("-0.1"), 10)}
+    assert_converge_in_precision {|n| log(BigDecimal("2"), n) }
+    assert_converge_in_precision {|n| log(BigDecimal("1e-30") + 1, n) }
+    assert_converge_in_precision {|n| log(BigDecimal("1e-30"), n) }
+    assert_converge_in_precision {|n| log(BigDecimal("1e30"), n) }
+    assert_converge_in_precision {|n| log(SQRT2, n) }
+    assert_raise(Math::DomainError) {log(BigDecimal("-0.1"), 10)}
     assert_separately(%w[-rbigdecimal], <<-SRC)
     begin
       x = BigMath.log(BigDecimal("1E19999999999999"), 10)
@@ -457,7 +457,7 @@ class TestBigMath < Test::Unit::TestCase
     assert_raise(Math::DomainError) { log1p(BigDecimal("-1.01"), N) }
     assert_in_epsilon(Math.log(0.01), log1p(BigDecimal("-0.99"), N))
     assert_positive_infinite_calculation { log1p(PINF, N) }
-    assert_in_exact_precision(BigMath.log(1 + BigDecimal("1e-20"), 100), log1p(BigDecimal("1e-20"), 100), 100)
+    assert_in_exact_precision(log(1 + BigDecimal("1e-20"), 100), log1p(BigDecimal("1e-20"), 100), 100)
   end
 
   def test_expm1
@@ -466,9 +466,9 @@ class TestBigMath < Test::Unit::TestCase
     assert_equal(-1, expm1(BigDecimal("-400"), 100))
     assert_equal(-1, expm1(BigDecimal("-231"), 100))
     assert_not_equal(-1, expm1(BigDecimal("-229"), 100))
-    assert_in_exact_precision(BigMath.exp(-220, 100) - 1, expm1(BigDecimal("-220"), 100), 100)
-    assert_in_exact_precision(BigMath.exp(-3, 100) - 1, expm1(BigDecimal("-3"), 100), 100)
-    assert_in_exact_precision(BigMath.exp(BigDecimal("1.23e-10"), 120) - 1, expm1(BigDecimal("1.23e-10"), 100), 100)
-    assert_in_exact_precision(BigMath.exp(123, 120) - 1, expm1(BigDecimal("123"), 100), 100)
+    assert_in_exact_precision(exp(-220, 100) - 1, expm1(BigDecimal("-220"), 100), 100)
+    assert_in_exact_precision(exp(-3, 100) - 1, expm1(BigDecimal("-3"), 100), 100)
+    assert_in_exact_precision(exp(BigDecimal("1.23e-10"), 120) - 1, expm1(BigDecimal("1.23e-10"), 100), 100)
+    assert_in_exact_precision(exp(123, 120) - 1, expm1(BigDecimal("123"), 100), 100)
   end
 end


### PR DESCRIPTION
BigMath methods are mostly module mehods, but exp and log were not (at least from v2.0.0).
There is no reason to exclude these two methods.
```ruby
include BigMath
# These works
sin(3.14, 10)
cos(3.14, 10)
atan(1, 10)
# These were error
exp(1, 10)
log(2, 10)
```

I don't think `include BigMath` is a good idea, but it is used in bigdecimal's document and also in test codes.
