### PR TITLE
Don't use assert_separatly if not needed

### DIFF
--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -786,15 +786,14 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_precs
-    assert_separately(["-rbigdecimal"], "#{<<~"begin;"}\n#{<<~'end;'}")
-    begin;
-      $VERBOSE = nil
-      a = BigDecimal("1").precs
-      assert_instance_of(Array, a)
-      assert_equal(2, a.size)
-      assert_kind_of(Integer, a[0])
-      assert_kind_of(Integer, a[1])
-    end;
+    $VERBOSE, verbose = nil, $VERBOSE
+    a = BigDecimal("1").precs
+    assert_instance_of(Array, a)
+    assert_equal(2, a.size)
+    assert_kind_of(Integer, a[0])
+    assert_kind_of(Integer, a[1])
+  ensure
+    $VERBOSE = verbose
   end
 
   def test_hash

--- a/test/bigdecimal/test_bigmath.rb
+++ b/test/bigdecimal/test_bigmath.rb
@@ -400,16 +400,14 @@ class TestBigMath < Test::Unit::TestCase
     assert_converge_in_precision {|n| log(BigDecimal("1e30"), n) }
     assert_converge_in_precision {|n| log(SQRT2, n) }
     assert_raise(Math::DomainError) {log(BigDecimal("-0.1"), 10)}
-    assert_separately(%w[-rbigdecimal], <<-SRC)
     begin
-      x = BigMath.log(BigDecimal("1E19999999999999"), 10)
+      x = BigDecimal("1E19999999999999")
     rescue FloatDomainError
     else
       unless x.infinite?
-        assert_in_epsilon(Math.log(10)*19999999999999, x)
+        assert_in_epsilon(Math.log(10) * 19999999999999, BigMath.log(x, 10))
       end
     end
-    SRC
   end
 
   def test_log2


### PR DESCRIPTION
Fixes ci failure in ruby-2.5 and 2.6
`precs` test doesn't need to be run separately as long as `$VERBOSE` is restored after the test.
`BigMath.log`'s assert_separately is added when it was implemented in C, but `BigMath.log` is now implemented in Ruby.
