### PR TITLE
Fix typos + improve copy/paste in readme

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,7 +80,7 @@
 
 * Fix memory leak in VpAlloc [GH-294] [GH-290]
 
-  Reoprted by **@MaxLap**
+  Reported by **@MaxLap**
 
 ## 3.1.7
 
@@ -211,7 +211,7 @@
 
   **Kenta Murata**
 
-* FIx the defaullt precision of `Float#to_d`.
+* Fix the default precision of `Float#to_d`.
   [Bug #13331]
 
   **Kenta Murata**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BigDecimal
 
-![CI](https://github.com/ruby/bigdecimal/workflows/CI/badge.svg?branch=master&event=push)
+[![CI](https://github.com/ruby/bigdecimal/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/ruby/bigdecimal/actions/workflows/ci.yml)
 
 BigDecimal provides an arbitrary-precision decimal floating-point number class.
 
@@ -14,11 +14,15 @@ gem 'bigdecimal'
 
 And then execute:
 
-    $ bundle
+```bash
+bundle
+```
 
 Or install it yourself as:
 
-    $ gem install bigdecimal
+```bash
+gem install bigdecimal
+```
 
 ### For RubyInstaller users
 


### PR DESCRIPTION
- Fix a few typos
- Make it easier to copy/paste from the readme by using code blocks
- Fix the CI badge