### PR TITLE
Fix lgamma precision around 1 and 2

### DIFF
--- a/test/bigdecimal/test_bigmath.rb
+++ b/test/bigdecimal/test_bigmath.rb
@@ -568,6 +568,10 @@ class TestBigMath < Test::Unit::TestCase
       assert_equal(sign, bigsign)
     end
     assert_equal([BigMath.log(PI(120).sqrt(120), 100), 1], lgamma(BigDecimal("0.5"), 100))
+    assert_converge_in_precision {|n| lgamma(BigDecimal("0." + "9" * 80), n).first }
+    assert_converge_in_precision {|n| lgamma(BigDecimal("1." + "0" * 80 + "1"), n).first }
+    assert_converge_in_precision {|n| lgamma(BigDecimal("1." + "9" * 80), n).first }
+    assert_converge_in_precision {|n| lgamma(BigDecimal("2." + "0" * 80 + "1"), n).first }
     assert_converge_in_precision {|n| lgamma(BigDecimal("-1." + "9" * 30), n).first }
     assert_converge_in_precision {|n| lgamma(BigDecimal("-3." + "0" * 30 + "1"), n).first }
     assert_converge_in_precision {|n| lgamma(BigDecimal("10"), n).first }


### PR DESCRIPTION
Followup of #451

When calculating `lgamma(2 + 1e-50, 100)`, internal calculation needs 100+50 digit precision.
When calculating `lgamma(2 + 1e-10000, 100)`, internal calculation needs 100+10000 digits precision but this is too slow.
Fortunately, in this case, linear interpolation between `x=2` and `x=2+1e-116` is enough to calculate `lgamma(2+1e-10000)`.