### PR TITLE
Fix lgamma precision when gamma(negative_x).abs nearly equals 1

### DIFF
--- a/test/bigdecimal/test_bigmath.rb
+++ b/test/bigdecimal/test_bigmath.rb
@@ -580,5 +580,9 @@ class TestBigMath < Test::Unit::TestCase
     assert_converge_in_precision {|n| lgamma(BigDecimal("987.65421"), n).first }
     assert_converge_in_precision {|n| lgamma(BigDecimal("-1234.56789"), n).first }
     assert_converge_in_precision {|n| lgamma(BigDecimal("1e+400"), n).first }
+
+    # gamma close 1 or -1 cases
+    assert_converge_in_precision {|n| lgamma(BigDecimal('-3.143580888349980058694358781820227899566'), n).first }
+    assert_converge_in_precision {|n| lgamma(BigDecimal('-4.991544640560047722345260122806465721667'), n).first }
   end
 end


### PR DESCRIPTION
There are many non-integer negative x that `gamma(x)` intersects with +1 or -1.
For example: `-2.4570247382208006`, `-2.7476826467274127`, `-3.14358088834998`, `-3.955294284858598` and so on.
Retry calculation with increased precision if the calculate value is not precise enough (by loss of significance error).

Fixes this bug:
```ruby
BigMath.lgamma(BigDecimal('-2.4570247382208006230394541'), 20)
# => [0.7222029201935e-25, -1] # on master branch. doesn't have 20 digits.
# => [0.72220292018028449792e-25, -1] # this pull request
```