### PR TITLE
Better rounding of BigMath.atan(nearly_one, prec)

### DIFF
--- a/lib/bigdecimal/math.rb
+++ b/lib/bigdecimal/math.rb
@@ -286,7 +286,7 @@ module BigMath
     pi = PI(n)
     x = -x if neg = x < 0
     return pi.div(neg ? -2 : 2, prec) if x.infinite?
-    return pi.div(neg ? -4 : 4, prec) if x.round(prec) == 1
+    return pi.div(neg ? -4 : 4, prec) if x.round(n) == 1
     x = BigDecimal("1").div(x, n) if inv = x > 1
     x = (-1 + sqrt(1 + x.mult(x, n), n)).div(x, n) if dbl = x > 0.5
     y = x

--- a/test/bigdecimal/test_bigmath.rb
+++ b/test/bigdecimal/test_bigmath.rb
@@ -278,6 +278,7 @@ class TestBigMath < Test::Unit::TestCase
     assert_converge_in_precision {|n| atan(BigDecimal("2"), n)}
     assert_converge_in_precision {|n| atan(BigDecimal("1e-30"), n)}
     assert_converge_in_precision {|n| atan(BigDecimal("1e30"), n)}
+    assert_equal(BigDecimal(0.78), BigMath.atan(0.996, 2))
   end
 
   def test_atan2


### PR DESCRIPTION
Fix `BigMath.atan(0.996, 2)` to return `0.78e0` instead of `0.79e0`
Precise value of `atan(0.996)` is `0.78339415806414066176194564660061...`
 