### PR TITLE
Remove deprecated method BigDecimal#precs

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -400,37 +400,6 @@ BigDecimal_double_fig(VALUE self)
     return INT2FIX(BIGDECIMAL_DOUBLE_FIGURES);
 }
 
-/*  call-seq:
- *    precs -> array
- *
- *  Returns an Array of two Integer values that represent platform-dependent
- *  internal storage properties.
- *
- *  This method is deprecated and will be removed in the future.
- *  Instead, use BigDecimal#n_significant_digits for obtaining the number of
- *  significant digits in scientific notation, and BigDecimal#precision for
- *  obtaining the number of digits in decimal notation.
- *
- */
-
-static VALUE
-BigDecimal_prec(VALUE self)
-{
-    BDVALUE v;
-    VALUE obj;
-
-    rb_category_warn(RB_WARN_CATEGORY_DEPRECATED,
-                     "BigDecimal#precs is deprecated and will be removed in the future; "
-                     "use BigDecimal#precision instead.");
-
-    v = GetBDValueMust(self);
-    obj = rb_assoc_new(SIZET2NUM(v.real->Prec*VpBaseFig()),
-		       SIZET2NUM(v.real->MaxPrec*VpBaseFig()));
-
-    RB_GC_GUARD(v.bigdecimal);
-    return obj;
-}
-
 static void
 VpCountPrecisionAndScale(Real *p, ssize_t *out_precision, ssize_t *out_scale)
 {
@@ -3593,7 +3562,6 @@ Init_bigdecimal(void)
     rb_define_const(rb_cBigDecimal, "NAN", BIGDECIMAL_LITERAL(NAN, NaN));
 
     /* instance methods */
-    rb_define_method(rb_cBigDecimal, "precs", BigDecimal_prec, 0);
     rb_define_method(rb_cBigDecimal, "precision", BigDecimal_precision, 0);
     rb_define_method(rb_cBigDecimal, "scale", BigDecimal_scale, 0);
     rb_define_method(rb_cBigDecimal, "precision_scale", BigDecimal_precision_scale, 0);

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -778,24 +778,6 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_operator(BigDecimal((2**100).to_s), :==, d)
   end
 
-  def test_precs_deprecated
-    assert_warn(/BigDecimal#precs is deprecated and will be removed in the future/) do
-      Warning[:deprecated] = true if defined?(Warning.[])
-      BigDecimal("1").precs
-    end
-  end
-
-  def test_precs
-    $VERBOSE, verbose = nil, $VERBOSE
-    a = BigDecimal("1").precs
-    assert_instance_of(Array, a)
-    assert_equal(2, a.size)
-    assert_kind_of(Integer, a[0])
-    assert_kind_of(Integer, a[1])
-  ensure
-    $VERBOSE = verbose
-  end
-
   def test_hash
     a = []
     b = BigDecimal("1")
@@ -832,11 +814,9 @@ class TestBigDecimal < Test::Unit::TestCase
     too_few_precs = BigDecimal._load('100:' + digits_part)
     assert_equal(1000, too_few_precs.precision)
     assert_equal(n, too_few_precs)
-    assert_equal(n.precs, too_few_precs.precs)
     too_large_precs = BigDecimal._load('999999999999:' + digits_part)
     assert_equal(1000, too_large_precs.precision)
     assert_equal(n, too_large_precs)
-    assert_equal(n.precs, too_large_precs.precs)
   ensure
     $VERBOSE = verbose
   end


### PR DESCRIPTION
`BigDecimal#precs` was deprecated in v3.0.0.
Next release (v4.0.0) is a good timing for removing it.