### PR TITLE
Deprecate ludcmp, jacobian and newton

### DIFF
--- a/lib/bigdecimal/jacobian.rb
+++ b/lib/bigdecimal/jacobian.rb
@@ -2,6 +2,8 @@
 
 require 'bigdecimal'
 
+warn "'bigdecimal/jacobian' is deprecated and will be removed in a future release."
+
 # require 'bigdecimal/jacobian'
 #
 # Provides methods to compute the Jacobian matrix of a set of equations at a

--- a/lib/bigdecimal/ludcmp.rb
+++ b/lib/bigdecimal/ludcmp.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: false
 require 'bigdecimal'
 
+warn "'bigdecimal/ludcmp' is deprecated and will be removed in a future release."
+
 #
 # Solves a*x = b for x, using LU decomposition.
 #

--- a/lib/bigdecimal/newton.rb
+++ b/lib/bigdecimal/newton.rb
@@ -2,6 +2,8 @@
 require "bigdecimal/ludcmp"
 require "bigdecimal/jacobian"
 
+warn "'bigdecimal/newton' is deprecated and will be removed in a future release."
+
 #
 # newton.rb
 #


### PR DESCRIPTION
It's not tested at all for a long time.
Jacobian and Newton is independent on BigDecimal, suggesting that it doesn't need to belong to bigdecimal.
Functionalty of ludcmp duplicates with `gem 'matrix'`.

These are rarely used.
## bigdecimal/jacobian
Nobody use it directly

## bigdecimal/ludcmp

About 5 repositories use it. [code search](https://github.com/search?q=%22bigdecimal%2Fludcmp%22+path%3A*.rb+NOT+path%3Abigdecimal%2Fludcmp.rb+NOT+bigdecimal%2Fjacobian+NOT+path%3Asample%2Flinear.rb+NOT+is%3Afork&type=code)

## bigdecimal/newton

About 13 repositories uses it. [code search](https://github.com/search?q=%22bigdecimal%2Fnewton%22+path%3A*.rb+NOT+path%3Abigdecimal%2Fnewton.rb+NOT+path%3Anlsolve.rb+NOT+path%3Atest_big_decimal.rb+NOT+is%3Afork&type=code)