### PR TITLE
Remove calculating log(10) in BigMath.log for large/small x

### DIFF
--- a/lib/bigdecimal.rb
+++ b/lib/bigdecimal.rb
@@ -303,10 +303,13 @@ module BigMath
 
     prec2 = prec + BigDecimal.double_fig
 
-    if x < 0.1 || x > 10
-      exponent = (3 * x).exponent - 1
-      x = x._decimal_shift(-exponent)
-      return log(10, prec2).mult(exponent, prec2).add(log(x, prec2), prec)
+    # Reduce x to near 1
+    if x > 1.01 || x < 0.99
+      # log(x) = log(x/exp(logx_approx)) + logx_approx
+      logx_approx = BigDecimal(BigDecimal::Internal.float_log(x), 0)
+      x = x.div(exp(logx_approx, prec2), prec2)
+    else
+      logx_approx = BigDecimal(0)
     end
 
     # Solve exp(y) - x = 0 with Newton's method
@@ -317,7 +320,7 @@ module BigMath
       expy = exp(y, p + exp_additional_prec)
       y = y.sub(expy.sub(x, p).div(expy, p), p)
     end
-    y.mult(1, prec)
+    y.add(logx_approx, prec)
   end
 
   private_class_method def _exp_binary_splitting(x, prec) # :nodoc:


### PR DESCRIPTION
Remove slow calculation of `log(10)`.
Before: `log(x) = log(10)*n + log(x/10**n)`
After: `log(x) = log(x/exp(logx_approx)) + logx_approx`

This optimization is based on https://bugs.ruby-lang.org/issues/6857#note-4

| code | v4.0.1 | master | this PR |
| --- | --- | --- | --- |
| BigMath.log(123, 100) | 0.000321832s | 0.001606367s | 0.000444787s |
| BigMath.log(123, 1000) | 0.009101423s | 0.011210634s | 0.003876186s |
| BigMath.log(123, 10000) | 2.029444s | 0.1657416s | 0.0709938s |
| BigMath.log(1.23, 100) | 0.000144828s | 0.000723668s | 0.000388832s |
| BigMath.log(1.23, 1000) | 0.00455668s | 0.00524359s | 0.00349395s |
| BigMath.log(1.23, 10000) | 1.026394s | 0.0884704s | 0.0646281s |

When prec is 100, master branch got few times slower than v4.0.1. This pull request will make a bit better.