### PR TITLE
Assume always have uint64_t

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
   host:
     needs: ruby-versions
-    name: ${{ matrix.os }} ${{ matrix.ruby }} decdig-${{ matrix.decdig_bits }}bit
+    name: ${{ matrix.os }} ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -31,19 +31,14 @@ jobs:
         - macos-14
         - windows-latest
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
-        decdig_bits: [32]
         include:
-        - { os: ubuntu-latest, ruby: "3.4", decdig_bits: 16 }
         - { os: windows-latest , ruby: mingw }
         - { os: windows-latest , ruby: mswin }
         exclude:
-        - { os: macos-latest   , ruby: "2.5" }
-        - { os: macos-14  , ruby: "2.5" }
         - { os: windows-latest , ruby: debug }
         - { os: windows-latest , ruby: truffleruby }
         - { os: windows-latest , ruby: truffleruby-head }
     env:
-      BIGDECIMAL_USE_DECDIG_UINT16_T: ${{ matrix.decdig_bits == 16 }}
       BIGDECIMAL_USE_VP_TEST_METHODS: true
       BUNDLE_WITHOUT: sig
 

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -29,18 +29,14 @@
 #endif
 
 #include "bits.h"
+#include "ntt.h"
 #include "div.h"
 #include "static_assert.h"
 
 #define BIGDECIMAL_VERSION "4.0.1"
 
-#if SIZEOF_DECDIG == 4
-#define USE_NTT_MULTIPLICATION 1
-#include "ntt.h"
 #define NTT_MULTIPLICATION_THRESHOLD 100
 #define NEWTON_RAPHSON_DIVISION_THRESHOLD 200
-#endif
-
 #define SIGNED_VALUE_MAX INTPTR_MAX
 #define SIGNED_VALUE_MIN INTPTR_MIN
 #define MUL_OVERFLOW_SIGNED_VALUE_P(a, b) MUL_OVERFLOW_SIGNED_INTEGER_P(a, b, SIGNED_VALUE_MIN, SIGNED_VALUE_MAX)
@@ -3279,7 +3275,6 @@ BigDecimal_vpmult(VALUE self, VALUE v) {
     return c.bigdecimal;
 }
 
-#if SIZEOF_DECDIG == 4
 VALUE
 BigDecimal_nttmult(VALUE self, VALUE v) {
     BDVALUE a,b,c;
@@ -3295,7 +3290,6 @@ BigDecimal_nttmult(VALUE self, VALUE v) {
     RB_GC_GUARD(b.bigdecimal);
     return c.bigdecimal;
 }
-#endif
 
 #endif /* BIGDECIMAL_USE_VP_TEST_METHODS */
 
@@ -3670,9 +3664,7 @@ Init_bigdecimal(void)
     rb_define_method(rb_cBigDecimal, "vpdivd_newton", BigDecimal_vpdivd_newton, 2);
     rb_define_method(rb_cBigDecimal, "newton_raphson_inverse", BigDecimal_newton_raphson_inverse, 1);
     rb_define_method(rb_cBigDecimal, "vpmult", BigDecimal_vpmult, 1);
-#ifdef USE_NTT_MULTIPLICATION
     rb_define_method(rb_cBigDecimal, "nttmult", BigDecimal_nttmult, 1);
-#endif
 #endif /* BIGDECIMAL_USE_VP_TEST_METHODS */
 
 #define ROUNDING_MODE(i, name, value) \
@@ -4956,13 +4948,11 @@ VpMult(Real *c, Real *a, Real *b)
     VpSetSign(c, VpGetSign(a) * VpGetSign(b));    /* set sign  */
     if (!AddExponent(c, b->exponent)) return 0;
 
-#ifdef USE_NTT_MULTIPLICATION
     if (b->Prec >= NTT_MULTIPLICATION_THRESHOLD) {
         ntt_multiply((uint32_t)a->Prec, (uint32_t)b->Prec, a->frac, b->frac, c->frac);
         c->Prec = a->Prec + b->Prec;
         goto Cleanup;
     }
-#endif
 
     carry = 0;
     nc = ind_c = MxIndAB;
@@ -5059,13 +5049,11 @@ VpDivd(Real *c, Real *r, Real *a, Real *b)
 
     if (word_a > word_r || word_b + word_c - 2 >= word_r) goto space_error;
 
-#ifdef USE_NTT_MULTIPLICATION
     // Newton-Raphson division requires multiplication to be faster than O(n^2)
     if (word_c >= NEWTON_RAPHSON_DIVISION_THRESHOLD && word_b >= NEWTON_RAPHSON_DIVISION_THRESHOLD) {
         VpDivdNewton(c, r, a, b);
         goto Exit;
     }
-#endif
 
     for (i = 0; i < word_a; ++i) r->frac[i] = a->frac[i];
     for (i = word_a; i < word_r; ++i) r->frac[i] = 0;

--- a/ext/bigdecimal/bigdecimal.h
+++ b/ext/bigdecimal/bigdecimal.h
@@ -17,24 +17,15 @@
 # include <float.h>
 #endif
 
-#if defined(HAVE_INT64_T) && !defined(BIGDECIMAL_USE_DECDIG_UINT16_T)
-# define DECDIG uint32_t
-# define DECDIG_DBL uint64_t
-# define DECDIG_DBL_SIGNED int64_t
-# define SIZEOF_DECDIG 4
-# define PRI_DECDIG_PREFIX ""
-# ifdef PRI_LL_PREFIX
-#  define PRI_DECDIG_DBL_PREFIX PRI_LL_PREFIX
-# else
-#  define PRI_DECDIG_DBL_PREFIX "l"
-# endif
+#define DECDIG uint32_t
+#define DECDIG_DBL uint64_t
+#define DECDIG_DBL_SIGNED int64_t
+#define SIZEOF_DECDIG 4
+#define PRI_DECDIG_PREFIX ""
+#ifdef PRI_LL_PREFIX
+# define PRI_DECDIG_DBL_PREFIX PRI_LL_PREFIX
 #else
-# define DECDIG uint16_t
-# define DECDIG_DBL uint32_t
-# define DECDIG_DBL_SIGNED int32_t
-# define SIZEOF_DECDIG 2
-# define PRI_DECDIG_PREFIX "h"
-# define PRI_DECDIG_DBL_PREFIX ""
+# define PRI_DECDIG_DBL_PREFIX "l"
 #endif
 
 #define PRIdDECDIG PRI_DECDIG_PREFIX"d"
@@ -51,31 +42,15 @@
 #define PRIxDECDIG_DBL PRI_DECDIG_DBL_PREFIX"x"
 #define PRIXDECDIG_DBL PRI_DECDIG_DBL_PREFIX"X"
 
-#if SIZEOF_DECDIG == 4
-# define BIGDECIMAL_BASE ((DECDIG)1000000000U)
-# define BIGDECIMAL_COMPONENT_FIGURES 9
+#define BIGDECIMAL_BASE ((DECDIG)1000000000U)
+#define BIGDECIMAL_COMPONENT_FIGURES 9
 /*
  * The number of components required for a 64-bit integer.
  *
  *   INT64_MAX:   9_223372036_854775807
  *   UINT64_MAX: 18_446744073_709551615
  */
-# define BIGDECIMAL_INT64_MAX_LENGTH 3
-
-#elif SIZEOF_DECDIG == 2
-# define BIGDECIMAL_BASE ((DECDIG)10000U)
-# define BIGDECIMAL_COMPONENT_FIGURES 4
-/*
- * The number of components required for a 64-bit integer.
- *
- *   INT64_MAX:   922_3372_0368_5477_5807
- *   UINT64_MAX: 1844_6744_0737_0955_1615
- */
-# define BIGDECIMAL_INT64_MAX_LENGTH 5
-
-#else
-# error Unknown size of DECDIG
-#endif
+#define BIGDECIMAL_INT64_MAX_LENGTH 3
 
 #define BIGDECIMAL_DOUBLE_FIGURES (1+DBL_DIG)
 

--- a/ext/bigdecimal/extconf.rb
+++ b/ext/bigdecimal/extconf.rb
@@ -52,7 +52,6 @@ else
   bigdecimal_rb = "$(srcdir)/../../lib/bigdecimal.rb"
 end
 
-$defs.push '-DBIGDECIMAL_USE_DECDIG_UINT16_T' if ENV['BIGDECIMAL_USE_DECDIG_UINT16_T'] == 'true'
 $defs.push '-DBIGDECIMAL_USE_VP_TEST_METHODS' if ENV['BIGDECIMAL_USE_VP_TEST_METHODS'] == 'true'
 
 create_makefile('bigdecimal') {|mf|

--- a/test/bigdecimal/helper.rb
+++ b/test/bigdecimal/helper.rb
@@ -5,14 +5,7 @@ require 'rbconfig/sizeof'
 
 module TestBigDecimalBase
   BASE = BigDecimal::BASE
-  case BASE
-  when 1000000000
-    SIZEOF_DECDIG = RbConfig::SIZEOF["int32_t"]
-    BASE_FIG = 9
-  when 10000
-    SIZEOF_DECDIG = RbConfig::SIZEOF["int16_t"]
-    BASE_FIG = 4
-  end
+  BASE_FIG = 9
 
   def setup
     @mode = BigDecimal.mode(BigDecimal::EXCEPTION_ALL)

--- a/test/bigdecimal/test_bigdecimal.rb
+++ b/test/bigdecimal/test_bigdecimal.rb
@@ -108,13 +108,8 @@ class TestBigDecimal < Test::Unit::TestCase
   def test_BigDecimal_issue_192
     # https://github.com/ruby/bigdecimal/issues/192
     # https://github.com/rails/rails/pull/42125
-    if BASE_FIG == 9
-      int = 1_000_000_000_12345_0000
-      big = BigDecimal("0.100000000012345e19")
-    else  # BASE_FIG == 4
-      int = 1_0000_12_00
-      big = BigDecimal("0.1000012e9")
-    end
+    int = 1_000_000_000_12345_0000
+    big = BigDecimal("0.100000000012345e19")
     assert_equal(BigDecimal(int), big, "[ruby/bigdecimal#192]")
   end
 

--- a/test/bigdecimal/test_bigdecimal_util.rb
+++ b/test/bigdecimal/test_bigdecimal_util.rb
@@ -65,13 +65,8 @@ class TestBigDecimalUtil < Test::Unit::TestCase
   def test_Float_to_d_issue_192
     # https://github.com/ruby/bigdecimal/issues/192
     # https://github.com/rails/rails/pull/42125
-    if BASE_FIG == 9
-      flo = 1_000_000_000.12345
-      big = BigDecimal("0.100000000012345e10")
-    else  # BASE_FIG == 4
-      flo = 1_0000.12
-      big = BigDecimal("0.1000012e5")
-    end
+    flo = 1_000_000_000.12345
+    big = BigDecimal("0.100000000012345e10")
     assert_equal(flo.to_d, big, "[ruby/bigdecimal#192]")
   end
 

--- a/test/bigdecimal/test_vp_operation.rb
+++ b/test/bigdecimal/test_vp_operation.rb
@@ -13,10 +13,6 @@ class TestVpOperation < Test::Unit::TestCase
     end
   end
 
-  def ntt_mult_available?
-    BASE_FIG == 9
-  end
-
   def test_vpmult
     assert_equal(BigDecimal('121932631112635269'), BigDecimal('123456789').vpmult(BigDecimal('987654321')))
     assert_equal(BigDecimal('12193263.1112635269'), BigDecimal('123.456789').vpmult(BigDecimal('98765.4321')))
@@ -26,7 +22,6 @@ class TestVpOperation < Test::Unit::TestCase
   end
 
   def test_nttmult
-    omit 'NTT multiplication is only available for 32-bit DECDIG' unless ntt_mult_available?
     [*1..32].repeated_permutation(2) do |a, b|
       x = BigDecimal(10 ** (BASE_FIG * a) / 7)
       y = BigDecimal(10 ** (BASE_FIG * b) / 13)
@@ -68,10 +63,8 @@ class TestVpOperation < Test::Unit::TestCase
       BigDecimal.limit 3
       assert_equal(xy, x.vpmult(y))
       assert_equal(3, BigDecimal.limit)
-      if ntt_mult_available?
-        assert_equal(xy, x.nttmult(y))
-        assert_equal(3, BigDecimal.limit)
-      end
+      assert_equal(xy, x.nttmult(y))
+      assert_equal(3, BigDecimal.limit)
 
       prec = (z.exponent - 1) / BASE_FIG - (y.exponent - 1) / BASE_FIG + 1
       assert_equal([x, mod], z.vpdivd(y, prec))
@@ -176,16 +169,9 @@ class TestVpOperation < Test::Unit::TestCase
   end
 
   def test_vpdivd_intermediate_zero
-    if BASE_FIG == 9
-      x = BigDecimal('123456789.246913578000000000123456789')
-      y = BigDecimal('123456789')
-      assert_vpdivd_equal([BigDecimal('1.000000002000000000000000001'), BigDecimal(0)], [x, y, 4])
-      assert_vpdivd_equal([BigDecimal('1.000000000049999999'), BigDecimal('1e-18')], [BigDecimal("2.000000000099999999"), 2, 3])
-    else
-      x = BigDecimal('1234.246800001234')
-      y = BigDecimal('1234')
-      assert_vpdivd_equal([BigDecimal('1.000200000001'), BigDecimal(0)], [x, y, 4])
-      assert_vpdivd_equal([BigDecimal('1.00000499'), BigDecimal('1e-8')], [BigDecimal("2.00000999"), 2, 3])
-    end
+    x = BigDecimal('123456789.246913578000000000123456789')
+    y = BigDecimal('123456789')
+    assert_vpdivd_equal([BigDecimal('1.000000002000000000000000001'), BigDecimal(0)], [x, y, 4])
+    assert_vpdivd_equal([BigDecimal('1.000000000049999999'), BigDecimal('1e-18')], [BigDecimal("2.000000000099999999"), 2, 3])
   end
 end


### PR DESCRIPTION
Always use DECDIG=uint32_t. DECDIG multiplication result will be `uint64_t`.

BigDecimal already requires uint64_t from v3.1.0 (https://github.com/ruby/bigdecimal/pull/178) and using it without `#if defined(HAVE_INT64_T)` guard. So this pull request will just remove dead code.