### PR TITLE
Bump version to 4.1.0

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -33,7 +33,7 @@
 #include "div.h"
 #include "static_assert.h"
 
-#define BIGDECIMAL_VERSION "4.0.1"
+#define BIGDECIMAL_VERSION "4.1.0"
 
 #define NTT_MULTIPLICATION_THRESHOLD 100
 #define NEWTON_RAPHSON_DIVISION_THRESHOLD 200


### PR DESCRIPTION
Diff: https://github.com/ruby/bigdecimal/compare/v4.0.1...4782fc5

Main change
- Drop Ruby 2.5 support
- Performance
  - Number Theoretic Transform multiplication 
  - Newton-Raphson division
  - Bit-burst BigMath methods
