### PR TITLE
Define `test` as the default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,8 +19,8 @@ Rake::TestTask.new do |t|
   t.warning = true
 end
 
-task travis: :test
 task test: :compile
+task default: :test
 
 benchmark_tasks = []
 namespace :benchmark do


### PR DESCRIPTION
I'm used to run rake without argument on most project, always surprises me when it doesn't work.