### PR TITLE
Update to cover change in Bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ gem 'bigdecimal'
 And then execute:
 
 ```bash
-bundle
+bundle install
 ```
 
 Or install it yourself as:


### PR DESCRIPTION
Since `install` is no longer the default subcommand for everyone (as of Bundler 4), the explicit `bundle install` is better.