### PR TITLE
Revert "Add a workaround for slow BigDecimal#to_f when it has large N_significant_digits"

### DIFF
--- a/lib/bigdecimal.rb
+++ b/lib/bigdecimal.rb
@@ -76,18 +76,9 @@ class BigDecimal
       end
     end
 
-    # Fast and rough conversion to float for mathematical calculations.
-    # Bigdecimal#to_f is slow when n_significant_digits is large.
-    # This is because to_f internally converts BigDecimal to String
-    # to get the exact nearest float representation.
-    # TODO: Remove this workaround when BigDecimal#to_f is optimized.
-    def self.fast_to_f(x) # :nodoc:
-      x.n_significant_digits < 40 ? x.to_f : x.mult(1, 20).to_f
-    end
-
     # Calculates Math.log(x.to_f) considering large or small exponent
     def self.float_log(x) # :nodoc:
-      Math.log(fast_to_f(x._decimal_shift(-x.exponent))) + x.exponent * Math.log(10)
+      Math.log(x._decimal_shift(-x.exponent).to_f) + x.exponent * Math.log(10)
     end
 
     # Calculating Taylor series sum using binary splitting method
@@ -277,7 +268,7 @@ class BigDecimal
 
     ex = exponent / 2
     x = _decimal_shift(-2 * ex)
-    y = BigDecimal(Math.sqrt(BigDecimal::Internal.fast_to_f(x)), 0)
+    y = BigDecimal(Math.sqrt(x.to_f), 0)
     Internal.newton_loop(prec + BigDecimal::Internal::EXTRA_PREC) do |p|
       y = y.add(x.div(y, p), p).div(2, p)
     end

--- a/lib/bigdecimal/math.rb
+++ b/lib/bigdecimal/math.rb
@@ -144,7 +144,7 @@ module BigMath
     x = -x if neg = x < 0
     ex = x.exponent / 3
     x = x._decimal_shift(-3 * ex)
-    y = BigDecimal(Math.cbrt(BigDecimal::Internal.fast_to_f(x)), 0)
+    y = BigDecimal(Math.cbrt(x.to_f), 0)
     BigDecimal::Internal.newton_loop(prec + BigDecimal::Internal::EXTRA_PREC) do |p|
       y = (2 * y + x.div(y, p).div(y, p)).div(3, p)
     end
@@ -304,7 +304,7 @@ module BigMath
 
     # Solve tan(y) - x = 0 with Newton's method
     # Repeat: y -= (tan(y) - x) * cos(y)**2
-    y = BigDecimal(Math.atan(BigDecimal::Internal.fast_to_f(x)), 0)
+    y = BigDecimal(Math.atan(x.to_f), 0)
     BigDecimal::Internal.newton_loop(n) do |p|
       s = sin(y, p)
       c = (1 - s * s).sqrt(p)
@@ -605,7 +605,7 @@ module BigMath
     return BigDecimal(1) if x > 5000000000 # erf(5000000000) > 1 - 1e-10000000000000000000
 
     if x > 8
-      xf = BigDecimal::Internal.fast_to_f(x)
+      xf = x.to_f
       log10_erfc = -xf ** 2 / Math.log(10) - Math.log10(xf * Math::PI ** 0.5)
       erfc_prec = [prec + log10_erfc.ceil, 1].max
       erfc = _erfc_asymptotic(x, erfc_prec)
@@ -647,7 +647,7 @@ module BigMath
     # erfc(x) = 1 - erf(x) < exp(-x**2)/x/sqrt(pi)
     # Precision of erf(x) needs about log10(exp(-x**2)/x/sqrt(pi)) extra digits
     log10 = 2.302585092994046
-    xf = BigDecimal::Internal.fast_to_f(x)
+    xf = x.to_f
     high_prec = prec + BigDecimal::Internal::EXTRA_PREC + ((xf**2 + Math.log(xf) + Math.log(Math::PI)/2) / log10).ceil
     BigDecimal(1).sub(erf(x, high_prec), prec)
   end
@@ -698,7 +698,7 @@ module BigMath
     # sqrt(2)/2 + k*log(k) - k - 2*k*log(x) < -prec*log(10)
     # and the left side is minimized when k = x**2.
     prec += BigDecimal::Internal::EXTRA_PREC
-    xf = BigDecimal::Internal.fast_to_f(x)
+    xf = x.to_f
     kmax = (1..(xf ** 2).floor).bsearch do |k|
       Math.log(2) / 2 + k * Math.log(k) - k - 2 * k * Math.log(xf) < -prec * Math.log(10)
     end


### PR DESCRIPTION
This reverts commit 3bf735fbe41fb07832ddf01ff507d92ea1810b05.

`BigDecimal#to_s` for large n_significant_digits number became about 10 times fast.
`huge_n_significant_digit_number.to_f` is still not fast. It takes O(N) time although we only need first 16-digit for BigMath use-case, but `to_f` is no longer a bottleneck of BigMath and its test execution time anymore.
