### PR TITLE
Fix unary minus on unsigned type warning

### DIFF
--- a/ext/bigdecimal/div.h
+++ b/ext/bigdecimal/div.h
@@ -101,7 +101,7 @@ divmod_newton(VALUE x, VALUE y, VALUE *div_out, VALUE *mod_out) {
     BDVALUE div_result = NewZeroWrap(1, BIGDECIMAL_COMPONENT_FIGURES * (num_blocks * block_figs + 1));
     BDVALUE bdx = GetBDValueMust(x);
 
-    VALUE mod = BigDecimal_fix(BigDecimal_decimal_shift(x, SSIZET2NUM(-num_blocks * block_digits)));
+    VALUE mod = BigDecimal_fix(BigDecimal_decimal_shift(x, SSIZET2NUM(-(ssize_t)num_blocks * block_digits)));
     for (ssize_t i = num_blocks - 1; i >= 0; i--) {
         memset(divident.real->frac, 0, (y_figs + block_figs) * sizeof(DECDIG));
 
@@ -164,9 +164,9 @@ VpDivdNewtonInner(VALUE args_ptr)
     VpAsgn(r, r2.real, VpGetSign(a));
     AddExponent(c, a->exponent);
     AddExponent(c, -b->exponent);
-    AddExponent(c, -div_prec);
+    AddExponent(c, -(ssize_t)div_prec);
     AddExponent(r, a->exponent);
-    AddExponent(r, -base_prec - div_prec);
+    AddExponent(r, -(ssize_t)base_prec - (ssize_t)div_prec);
     RB_GC_GUARD(a2.bigdecimal);
     RB_GC_GUARD(a2.bigdecimal);
     RB_GC_GUARD(c2.bigdecimal);

--- a/ext/bigdecimal/div.h
+++ b/ext/bigdecimal/div.h
@@ -59,14 +59,14 @@ divmod_by_inv_mul(VALUE x, VALUE y, VALUE inv, VALUE *res_div, VALUE *res_mod) {
 
 static void
 slice_copy(DECDIG *dest, Real *src, size_t rshift, size_t length) {
-    ssize_t start = src->exponent - rshift - length;
+    ssize_t start = src->exponent - (ssize_t)rshift - (ssize_t)length;
     if (start >= (ssize_t)src->Prec) return;
     if (start < 0) {
         dest -= start;
-        length += start;
+        length -= (size_t)(-start);
         start = 0;
     }
-    size_t max_length = src->Prec - start;
+    size_t max_length = (size_t)((ssize_t)src->Prec - start);
     memcpy(dest, src->frac + start, Min(length, max_length) * sizeof(DECDIG));
 }
 
@@ -101,28 +101,28 @@ divmod_newton(VALUE x, VALUE y, VALUE *div_out, VALUE *mod_out) {
     BDVALUE div_result = NewZeroWrap(1, BIGDECIMAL_COMPONENT_FIGURES * (num_blocks * block_figs + 1));
     BDVALUE bdx = GetBDValueMust(x);
 
-    VALUE mod = BigDecimal_fix(BigDecimal_decimal_shift(x, SSIZET2NUM(-(ssize_t)num_blocks * block_digits)));
-    for (ssize_t i = num_blocks - 1; i >= 0; i--) {
+    VALUE mod = BigDecimal_fix(BigDecimal_decimal_shift(x, SSIZET2NUM(-(ssize_t)(num_blocks * block_digits))));
+    for (ssize_t i = (ssize_t)(num_blocks - 1); i >= 0; i--) {
         memset(divident.real->frac, 0, (y_figs + block_figs) * sizeof(DECDIG));
 
         BDVALUE bdmod = GetBDValueMust(mod);
         slice_copy(divident.real->frac, bdmod.real, 0, y_figs);
-        slice_copy(divident.real->frac + y_figs, bdx.real, i * block_figs, block_figs);
+        slice_copy(divident.real->frac + y_figs, bdx.real, (size_t)i * block_figs, block_figs);
         RB_GC_GUARD(bdmod.bigdecimal);
 
         VpSetSign(divident.real, 1);
-        divident.real->exponent = y_figs + block_figs;
+        divident.real->exponent = (ssize_t)(y_figs + block_figs);
         divident.real->Prec = y_figs + block_figs;
         VpNmlz(divident.real);
 
         VALUE div;
         divmod_by_inv_mul(divident.bigdecimal, y, yinv, &div, &mod);
         BDVALUE bddiv = GetBDValueMust(div);
-        slice_copy(div_result.real->frac + (num_blocks - i - 1) * block_figs, bddiv.real, 0, block_figs + 1);
+        slice_copy(div_result.real->frac + (num_blocks - (size_t)i - 1) * block_figs, bddiv.real, 0, block_figs + 1);
         RB_GC_GUARD(bddiv.bigdecimal);
     }
     VpSetSign(div_result.real, 1);
-    div_result.real->exponent = num_blocks * block_figs + 1;
+    div_result.real->exponent = (ssize_t)(num_blocks * block_figs + 1);
     div_result.real->Prec = num_blocks * block_figs + 1;
     VpNmlz(div_result.real);
     RB_GC_GUARD(bdx.bigdecimal);
@@ -148,8 +148,8 @@ VpDivdNewtonInner(VALUE args_ptr)
     VpAsgn(b2.real, b, 1);
     VpSetSign(a2.real, 1);
     VpSetSign(b2.real, 1);
-    a2.real->exponent = base_prec + div_prec;
-    b2.real->exponent = base_prec;
+    a2.real->exponent = (ssize_t)(base_prec + div_prec);
+    b2.real->exponent = (ssize_t)base_prec;
 
     if ((ssize_t)a2.real->Prec > a2.real->exponent) {
         a2_frac = BigDecimal_frac(a2.bigdecimal);
@@ -166,7 +166,7 @@ VpDivdNewtonInner(VALUE args_ptr)
     AddExponent(c, -b->exponent);
     AddExponent(c, -(ssize_t)div_prec);
     AddExponent(r, a->exponent);
-    AddExponent(r, -(ssize_t)base_prec - (ssize_t)div_prec);
+    AddExponent(r, -(ssize_t)(base_prec + div_prec));
     RB_GC_GUARD(a2.bigdecimal);
     RB_GC_GUARD(a2.bigdecimal);
     RB_GC_GUARD(c2.bigdecimal);

--- a/ext/bigdecimal/ntt.h
+++ b/ext/bigdecimal/ntt.h
@@ -68,7 +68,7 @@ ntt(int size_bits, uint32_t *input, uint32_t *output, uint32_t *tmp, int r_base,
 
     // rmax**(1 << shift) % prime == 1
     // r**size % prime == 1
-    uint32_t rmax = mod_pow(r_base, base, prime);
+    uint32_t rmax = mod_pow((uint32_t)r_base, (uint32_t)base, prime);
     uint32_t r = mod_pow(rmax, (uint32_t)1 << (shift - size_bits), prime);
 
     if (dir < 0) r = mod_pow(r, prime - 2, prime);
@@ -123,7 +123,7 @@ ntt_multiply(size_t a_size, size_t b_size, uint32_t *a, uint32_t *b, uint32_t *c
       return;
     }
 
-    int ntt_size_bits = bit_length(b_size - 1) + 1;
+    int ntt_size_bits = (int)bit_length(b_size - 1) + 1;
     if (ntt_size_bits > MAX_NTT32_BITS) {
       rb_raise(rb_eArgError, "Multiply size too large");
     }
@@ -177,12 +177,12 @@ ntt_multiply(size_t a_size, size_t b_size, uint32_t *a, uint32_t *b, uint32_t *c
             // so this sum doesn't overflow uint32_t.
             for (int j = 0; j < 3; j++) {
                 // Index check: if dig[j] is non-zero, assign index is within valid range.
-                if (dig[j]) c[idx * batch_size + i + 1 - j] += dig[j];
+                if (dig[j]) c[idx * batch_size + i + 1 - (uint32_t)j] += dig[j];
             }
         }
     }
     uint32_t carry = 0;
-    for (int32_t i = (uint32_t)(a_size + b_size - 1); i >= 0; i--) {
+    for (int32_t i = (int32_t)(a_size + b_size - 1); i >= 0; i--) {
         uint32_t v = c[i] + carry;
         c[i] = v % NTT_DECDIG_BASE;
         carry = v / NTT_DECDIG_BASE;


### PR DESCRIPTION
Fix `unary minus operator applied to unsigned type, result still unsigned` warning.
Fix some implicit conversion warning (if `-Wsign-conversion` is specified) in recently added `div.h` and `ntt.h`.