### PR TITLE
Bump version to v4.1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # CHANGES
 
+## 4.1.2
+
+* Fix dtoa Ractor-safety bug. Update dtoa to version from Ruby 4.0 [GH-528]
+
+  **@jhawthorn**
+
+* Optimize BigDecimal#to_s [GH-519]
+
+  **@byroot**
+
 ## 4.1.1
 
 * Make BigDecimal object embedded [GH-507]

--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -33,7 +33,7 @@
 #include "div.h"
 #include "static_assert.h"
 
-#define BIGDECIMAL_VERSION "4.1.1"
+#define BIGDECIMAL_VERSION "4.1.2"
 
 /* Make sure VPMULT_BATCH_SIZE*BASE*BASE does not overflow DECDIG_DBL */
 #define VPMULT_BATCH_SIZE 16


### PR DESCRIPTION
Fix dtoa multithread bug, Optimize BigDecimal#to_s, Fix compiler warnings, etc

https://github.com/ruby/bigdecimal/compare/v4.1.1...8050ec79c046665dff237bcd8f85d8ec830a9cc4