### PR TITLE
Fix conditional inclusion of stdckdint.h

### DIFF
--- a/ext/bigdecimal/missing/dtoa.c
+++ b/ext/bigdecimal/missing/dtoa.c
@@ -210,10 +210,14 @@
 #include <locale.h>
 #endif
 
-#if defined(HAVE_STDCKDINT_H) || !defined(__has_include)
-#elif __has_include(<stdckdint.h>)
+#if !defined(HAVE_STDCKDINT_H)
+#if defined(__has_include)
+#if __has_include(<stdckdint.h>)
 # define HAVE_STDCKDINT_H 1
 #endif
+#endif
+#endif
+
 #ifdef HAVE_STDCKDINT_H
 # include <stdckdint.h>
 #endif


### PR DESCRIPTION
Because `__has_include` is on a `#elif` line, it is still being evaluated by the pre-processor regardless of `#if defined`, even if not executed. It must exist on its own gated level inside of the `#if` block rather than at the same level as the `#if` block to function correctly.

This fixes a compilation error on a platform which doesn't have `__has_include` available.