### PR TITLE
Fix Newton inverse subtraction precision

### DIFF
--- a/ext/bigdecimal/div.h
+++ b/ext/bigdecimal/div.h
@@ -29,7 +29,7 @@ newton_raphson_inverse(VALUE x, size_t prec) {
         VALUE one_minus_x_inv = BigDecimal_sub2(
             one,
             BigDecimal_mult(BigDecimal_mult2(x, one, SIZET2NUM(n + 1)), inv),
-            SIZET2NUM(SIZET2NUM(n / 2))
+            SIZET2NUM(n / 2)
         );
         inv = BigDecimal_add2(
             inv,


### PR DESCRIPTION
Summary:
- remove an accidental nested SIZET2NUM conversion in Newton reciprocal iteration
- pass the intended n / 2 precision directly to BigDecimal_sub2

Why:
The current expression converts n / 2 to a Ruby Integer, then feeds that VALUE back to SIZET2NUM as though it were a native size_t. On tagged-integer builds this inflates the requested precision substantially and performs avoidable work.

Verification:
- full current suite: 266 tests, 13,616 assertions, 0 failures/errors/omissions
- RBS suite: 146 tests, 1,805 assertions, 0 failures/errors
- five controlled 50,000-digit reciprocal runs, 50 iterations each: baseline average 0.25346s; fixed average 0.20403s (about 19.5% faster)
- numerical accuracy invariant passed in every run

Compatibility:
The correction restores the precision value already expressed by the surrounding n / 2 calculation; results remain within the existing accuracy invariant.