### PR TITLE
Keep Newton division divisor alive

### DIFF
--- a/ext/bigdecimal/div.h
+++ b/ext/bigdecimal/div.h
@@ -168,7 +168,7 @@ VpDivdNewtonInner(VALUE args_ptr)
     AddExponent(r, a->exponent);
     AddExponent(r, -(ssize_t)(base_prec + div_prec));
     RB_GC_GUARD(a2.bigdecimal);
-    RB_GC_GUARD(a2.bigdecimal);
+    RB_GC_GUARD(b2.bigdecimal);
     RB_GC_GUARD(c2.bigdecimal);
     RB_GC_GUARD(r2.bigdecimal);
     return Qnil;


### PR DESCRIPTION
Summary:
- correct the second duplicated RB_GC_GUARD for a2 to guard b2
- retain the divisor wrapper through the end of VpDivdNewtonInner

Why:
The method constructs a2, b2, c2 and r2, but its final guards name a2 twice and omit b2. The duplicate is a maintenance/liveness typo at a native GC boundary.

Verification:
- full current suite: 266 tests, 13,616 assertions, 0 failures/errors/omissions
- RBS suite: 146 tests, 1,805 assertions, 0 failures/errors
- 25 GC.stress division comparisons pass before and after the correction

Compatibility:
No arithmetic behavior changes. This makes the existing lifetime intent explicit; the stress model did not reproduce a user-visible crash on the tested runtime.