### PR TITLE
Honor exception: false for complex conversion

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2898,7 +2898,7 @@ rb_convert_to_BigDecimal(VALUE val, size_t digs, int raise_exception)
     else if (RB_TYPE_P(val, T_COMPLEX)) {
         VALUE im = rb_complex_imag(val);
         if (!is_zero(im)) {
-            /* TODO: handle raise_exception */
+            if (!raise_exception) return Qnil;
             rb_raise(rb_eArgError,
                      "Unable to make a BigDecimal from non-zero imaginary number");
         }


### PR DESCRIPTION
Summary:
- return nil for Complex values with a nonzero imaginary part when exception: false
- preserve ArgumentError for the default and exception: true paths

Why:
Kernel.BigDecimal accepts exception: false as a non-raising conversion mode, but this Complex branch contains a TODO and always raises. That differs from the documented option and the method’s other invalid-input paths.

Verification:
- baseline reproduction raises ArgumentError for BigDecimal(Complex(1, 1), exception: false)
- fixed reproduction returns nil; exception: true still raises; zero-imaginary conversion is unchanged
- full current suite: 266 tests, 13,616 assertions, 0 failures/errors/omissions
- RBS suite: 146 tests, 1,805 assertions, 0 failures/errors

Compatibility:
Only the explicitly non-raising invalid-conversion path changes.