### PR TITLE
Honor exception: false for strings with null bytes

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -2845,6 +2845,7 @@ rb_cstr_convert_to_BigDecimal(const char *c_str, int raise_exception)
 static inline VALUE
 rb_str_convert_to_BigDecimal(VALUE val, int raise_exception)
 {
+    if (!raise_exception && memchr(RSTRING_PTR(val), '\0', RSTRING_LEN(val))) return Qnil;
     const char *c_str = StringValueCStr(val);
     return rb_cstr_convert_to_BigDecimal(c_str, raise_exception);
 }


### PR DESCRIPTION
Summary:
- detect embedded NUL bytes before StringValueCStr in non-raising conversion mode
- return nil when exception: false
- retain the existing ArgumentError when exceptions are enabled

Why:
StringValueCStr raises string contains null byte before BigDecimal’s parser can honor exception: false. Core Float and Integer conversions use their non-raising option for this case, and BigDecimal already documents the same conversion mode.

Verification:
- baseline reproduction raises for BigDecimal("1\0", exception: false)
- fixed reproduction returns nil; exception: true still raises; ordinary strings are unchanged
- full current suite: 266 tests, 13,616 assertions, 0 failures/errors/omissions
- RBS suite: 146 tests, 1,805 assertions, 0 failures/errors

Compatibility:
Only strings invalid because of an embedded NUL change in the explicitly non-raising mode.