### PR TITLE
Correct nullable BigDecimal conversion signature

### DIFF
--- a/sig/big_decimal.rbs
+++ b/sig/big_decimal.rbs
@@ -1237,7 +1237,9 @@ module Kernel
   # Raises an exception if `value` evaluates to a Float and `digits` is larger
   # than Float::DIG + 1.
   #
-  def self?.BigDecimal: (real | string | BigDecimal initial, ?int digits, ?exception: bool) -> BigDecimal
+  def self?.BigDecimal: (real | string | BigDecimal initial, ?int digits, ?exception: true) -> BigDecimal
+                      | (real | string | BigDecimal initial, ?int digits, exception: bool) -> BigDecimal?
+                      | (untyped initial, ?untyped digits, ?exception: bool) -> BigDecimal?
 end
 
 %a{annotate:rdoc:skip}


### PR DESCRIPTION
Summary:
- distinguish the default/exception: true overload from non-literal boolean calls
- return BigDecimal? whenever exception may be false
- add a conservative untyped fallback for the dynamic Kernel conversion API

Why:
Kernel.BigDecimal returns nil for failed conversions when exception: false, but the current RBS always declares BigDecimal. The overload shape follows the established Float, Integer and Complex signatures in core RBS.

Verification:
- full current suite: 266 tests, 13,616 assertions, 0 failures/errors/omissions
- RBS suite: 146 tests, 1,805 assertions, 0 failures/errors
- conversion model covers literal true, literal false, a boolean variable and dynamic inputs

Compatibility:
This changes type information only. Existing calls remain accepted while non-raising conversions receive their actual nullable return type.